### PR TITLE
fix(hideExpression): use getFieldModel only for simple field

### DIFF
--- a/src/core/src/components/formly.field.ts
+++ b/src/core/src/components/formly.field.ts
@@ -220,7 +220,7 @@ export class FormlyField implements OnInit, OnDestroy {
 
   private addFieldControl() {
     const parent = this.fieldParentFormControl,
-      model = getFieldModel(this.model, this.field, false);
+      model = (this.field.fieldGroup || this.field.fieldArray) ? this.model : getFieldModel(this.model, this.field, false);
     if (this.field.formControl.value !== model) {
       this.field.formControl.patchValue(model);
     }

--- a/src/core/src/components/formly.form.spec.ts
+++ b/src/core/src/components/formly.form.spec.ts
@@ -99,6 +99,28 @@ describe('Formly Form Component', () => {
       expect(getFormlyFieldElement(fixture.nativeElement).getAttribute('style')).toEqual('display: none;');
     });
 
+    it('should apply model changes when form is enabled', () => {
+      const form = new FormGroup({});
+      testComponentInputs.form = form;
+      testComponentInputs.model = {};
+      testComponentInputs.fields = [{
+        key: 'address',
+        hideExpression: () => true,
+        fieldGroup: [{
+          key: 'city',
+          type: 'text',
+        }],
+      }];
+
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>');
+      expect(form.get('address')).toBeNull();
+
+      testComponentInputs.fields[0].hideExpression = () => false;
+      testComponentInputs.model.address.city = 'test';
+      fixture.detectChanges();
+      expect(form.get('address.city').value).toEqual('test');
+    });
+
     it('should hide/display field using a function with nested field key', fakeAsync(() => {
       const form = new FormGroup({});
       testComponentInputs.form = form;


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/588)
<!-- Reviewable:end -->
