### PR TITLE
docs(Readme.md): Fixing the build status on the header of the Readme.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Stories in Ready](https://badge.waffle.io/formly-js/ng-formly.png?label=ready&title=Ready)](https://waffle.io/formly-js/ng-formly)
 
 Status:
-[![Build Status](https://travis-ci.org/formly-js/ng-formly.svg?branch=master)](https://travis-ci.org/formly-js/ng-formly)
+[![Build Status](https://travis-ci.org/formly-js/ngx-formly.svg?branch=master)](https://travis-ci.org/formly-js/ngx-formly)
 [![npm version](https://badge.fury.io/js/ng-formly.svg)](https://badge.fury.io/js/ng-formly)
 [![devDependencies Status](https://david-dm.org/formly-js/ng-formly/dev-status.svg)](https://david-dm.org/formly-js/ng-formly?type=dev)
 [![Package Quality](http://npm.packagequality.com/shield/ng-formly.png)](http://packagequality.com/#?package=ng-formly)


### PR DESCRIPTION
The header of the Readme.md for the repo has a build status link that currently points to:
https://travis-ci.org/formly-js/ng-formly, this should be repointed to ngx-formly as it's currently
showing a build status of unknown when in fact it is passing.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs Update


**What is the current behavior? (You can also link to an open issue here)**
Build status shows build as broken and link is pointed at the wrong repo


**What is the new behavior (if this is a feature change)?**
Build status now shows successful build and link is pointed at the correct repo


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/603)
<!-- Reviewable:end -->
