### PR TITLE
feat(label): Add an asterisk to ui-material fields when required

### DIFF
--- a/src/ui-material/src/wrappers/form-field.ts
+++ b/src/ui-material/src/wrappers/form-field.ts
@@ -12,7 +12,11 @@ import { takeUntil } from 'rxjs/operator/takeUntil';
     <!-- fix https://github.com/angular/material2/pull/7083 by setting width to 100% -->
     <mat-form-field [floatLabel]="to.floatLabel" [style.width]="'100%'">
       <ng-container #fieldComponent></ng-container>
-      <mat-label *ngIf="to.label && field.type !== 'checkbox'">{{ to.label }}</mat-label>
+      <mat-label *ngIf="to.label && field.type !== 'checkbox'">
+        {{ to.label }}
+        <span *ngIf="to.required" class="mat-form-field-required-marker">*</span>
+      </mat-label>
+
       <mat-placeholder *ngIf="to.placeholder">{{ to.placeholder }}</mat-placeholder>
       <!-- fix https://github.com/angular/material2/issues/7737 by setting id to null  -->
       <mat-error [id]="null">


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature, fix #604

**What is the current behavior? (You can also link to an open issue here)**

Material design labels do not show an asterisk when field is required (as the bootstrap do).

**What is the new behavior (if this is a feature change)?**

Material design labels now show an asterisk as the bootstrap labels do.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/609)
<!-- Reviewable:end -->
