### PR TITLE
fix(core): avoid calling deepMerge for readonly property.

### DIFF
--- a/src/core/src/components/formly.form.ts
+++ b/src/core/src/components/formly.form.ts
@@ -178,7 +178,6 @@ export class FormlyForm implements DoCheck, OnChanges {
   }
 
   private updateInitialValue() {
-    const initialModel = reverseDeepMerge(this.form.value, this.model);
-    this.initialModel = JSON.parse(JSON.stringify(initialModel));
+    this.initialModel = reverseDeepMerge({}, this.model);
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/626)
<!-- Reviewable:end -->
