### PR TITLE
fix(material): ensure calls to lifecycle hooks

### DIFF
--- a/src/ui-material/src/types/checkbox.ts
+++ b/src/ui-material/src/types/checkbox.ts
@@ -18,5 +18,6 @@ export class FormlyFieldCheckbox extends FieldType implements AfterViewInit {
     if (this.field['__formField__']) {
       this.field['__formField__']._control.focusMonitor([this.matCheckbox._inputElement.nativeElement]);
     }
+    super.ngAfterViewInit();
   }
 }

--- a/src/ui-material/src/types/input.ts
+++ b/src/ui-material/src/types/input.ts
@@ -26,5 +26,6 @@ export class FormlyFieldInput extends FieldType implements OnInit {
     if (this.field['__formField__']) {
       this.field['__formField__']._control = this.matInput;
     }
+    super.ngOnInit();
   }
 }

--- a/src/ui-material/src/types/multicheckbox.ts
+++ b/src/ui-material/src/types/multicheckbox.ts
@@ -33,5 +33,6 @@ export class FormlyFieldMultiCheckbox extends FieldType implements AfterViewInit
         this.matCheckboxes.map(matCheckbox => matCheckbox._inputElement.nativeElement),
       );
     }
+    super.ngAfterViewInit();
   }
 }

--- a/src/ui-material/src/types/radio.ts
+++ b/src/ui-material/src/types/radio.ts
@@ -21,5 +21,6 @@ export class FormlyFieldRadio extends FieldType implements AfterViewInit {
         this.matRadioButtons.map(matRadioButton => matRadioButton._inputElement.nativeElement),
       );
     }
+    super.ngAfterViewInit();
   }
 }

--- a/src/ui-material/src/types/select.ts
+++ b/src/ui-material/src/types/select.ts
@@ -74,5 +74,6 @@ export class FormlyFieldSelect extends FieldType implements OnInit {
     if (this.field['__formField__']) {
       this.field['__formField__']._control = this.matSelect;
     }
+    super.ngOnInit();
   }
 }


### PR DESCRIPTION
Fixes material field types not calling lifecycle hooks due to method overrides

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
Material field types that implement Angular lifecycle hooks do not call the corresponding field lifecycle hook.


**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/628)
<!-- Reviewable:end -->
