### PR TITLE
fix(core): add default wrappers when type is set

### DIFF
--- a/src/core/src/services/formly.config.ts
+++ b/src/core/src/services/formly.config.ts
@@ -36,7 +36,7 @@ export class FormlyConfig {
   } = {
     fieldTransform: undefined,
     showError: function(field: Field) {
-      return (field.formControl.touched || (field.options.parentForm && field.options.parentForm.submitted) || (field.field.validation && field.field.validation.show)) && field.formControl.invalid;
+      return field.formControl && field.formControl.invalid && (field.formControl.touched || (field.options.parentForm && field.options.parentForm.submitted) || (field.field.validation && field.field.validation.show));
     },
   };
 

--- a/src/core/src/services/formly.form.builder.spec.ts
+++ b/src/core/src/services/formly.form.builder.spec.ts
@@ -258,6 +258,13 @@ describe('FormlyFormBuilder service', () => {
       expect(field.key).toEqual('nested.title');
       expect(field.wrappers).toEqual([]);
     });
+
+    it('should add default wrappers if type is provided', () => {
+      field = { type: 'input' };
+      builder.buildForm(form, [field], {}, {});
+
+      expect(field.wrappers).toEqual(['label']);
+    });
   });
 
   describe('initialise field validators', () => {

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -141,13 +141,15 @@ export class FormlyFormBuilder {
 
   private initFieldOptions(field: FormlyFieldConfig) {
     field.templateOptions = field.templateOptions || {};
-    if (field.key && field.type) {
+    if (field.type) {
       this.formlyConfig.getMergedField(field);
-      field.templateOptions = Object.assign({
-        label: '',
-        placeholder: '',
-        focus: false,
-      }, field.templateOptions);
+      if (field.key) {
+        field.templateOptions = Object.assign({
+          label: '',
+          placeholder: '',
+          focus: false,
+        }, field.templateOptions);
+      }
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/630)
<!-- Reviewable:end -->
