### PR TITLE
fix(bootstrap): add missing `control-label` class for label

### DIFF
--- a/src/ui-bootstrap/src/wrappers/label.ts
+++ b/src/ui-bootstrap/src/wrappers/label.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
   selector: 'formly-wrapper-label',
   template: `
-    <label [attr.for]="id" class="form-control-label">
+    <label [attr.for]="id" class="form-control-label control-label">
       {{ to.label }}
       {{ to.required ? '*' : '' }}
     </label>


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

fix #633

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/637)
<!-- Reviewable:end -->
