### PR TITLE
feat(bootstrap): support bootstrap 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "angular-cli-ghpages": "^0.5.2",
     "angular2-template-loader": "^0.6.2",
     "awesome-typescript-loader": "^3.4.0",
-    "bootstrap": "4.0.0-beta.3",
+    "bootstrap": "^4.0.0",
     "bundlesize": "^0.15.3",
     "codecov": "^3.0.0",
     "codelyzer": "^4.0.1",

--- a/src/ui-bootstrap/package.json
+++ b/src/ui-bootstrap/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "tslib": "^1.7.1",
-    "@ngx-formly/core": "FORMLY-VERSION"
+    "@ngx-formly/core": "FORMLY-VERSION",
+    "bootstrap": "^4.0.0 || ^3.3.7"
   }
 }

--- a/src/ui-bootstrap/src/types/checkbox.ts
+++ b/src/ui-bootstrap/src/types/checkbox.ts
@@ -4,15 +4,16 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'formly-field-checkbox',
   template: `
-    <label class="custom-control custom-checkbox">
+    <div class="custom-control custom-checkbox">
       <input type="checkbox" [formControl]="formControl"
         [attr.invalid]="showError"
         [indeterminate]="model[key] === undefined"
         [formlyAttributes]="field" class="custom-control-input">
-        {{ to.label }}
-        {{ to.required ? '*' : '' }}
-        <span class="custom-control-indicator"></span>
-    </label>
+        <label class="custom-control-label" [attr.for]="id">
+          {{ to.label }}
+          {{ to.required ? '*' : '' }}
+        </label>
+    </div>
   `,
 })
 export class FormlyFieldCheckbox extends FieldType {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -868,9 +868,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.3.tgz#60f0660bc3d121176514b361f6f83201c7ff8874"
+bootstrap@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
**What kind of change does this PR introduce? feature**

BREAKING CHANGE: bootstrap 4.0.0-beta is no longer supported.

fix #679

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/680)
<!-- Reviewable:end -->
