### PR TITLE
Fix Issue: parsers as array of functions declaration #684

### DIFF
--- a/src/core/src/components/formly.field.config.ts
+++ b/src/core/src/components/formly.field.config.ts
@@ -147,7 +147,7 @@ export interface FormlyFieldConfig {
   /**
    * Array of functions to execute, as a pipeline, whenever the model updates, usually via user input.
    */
-  parsers?: [(value: any, index: number) => {}];
+  parsers?: ((value: any, index: number) => {})[];
 }
 
 export interface FormlyTemplateOptions {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Solve the issue [Parsers as array of functions declaration](https://github.com/formly-js/ngx-formly/issues/684)

**What is the current behavior? (You can also link to an open issue here)**
[Parsers as array of functions declaration](https://github.com/formly-js/ngx-formly/issues/684)


**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [*] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/685)
<!-- Reviewable:end -->
