### PR TITLE
feat(core): support using `className` in expressionProperties.

### DIFF
--- a/src/core/src/components/formly.form.spec.ts
+++ b/src/core/src/components/formly.form.spec.ts
@@ -188,6 +188,20 @@ describe('Formly Form Component', () => {
       testComponentInputs = { fields: [field], model, form };
     });
 
+    it('className', () => {
+      field.expressionProperties = {
+        'field.className': 'model.title',
+      };
+
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>');
+      expect(field.className).toEqual(undefined);
+
+      model.title = 'test';
+      fixture.detectChanges();
+
+      expect(field.className).toEqual('test');
+    });
+
     it('templateOptions.disabled', () => {
       field.expressionProperties = {
         'templateOptions.disabled': 'model.title !== undefined',

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -133,7 +133,7 @@ export class FormlyFormBuilder {
           // cache built expression
           field.expressionProperties[key] = {
             expression: isFunction(field.expressionProperties[key]) ? field.expressionProperties[key] : evalStringExpression(field.expressionProperties[key], ['model', 'formState']),
-            expressionValueSetter: evalExpressionValueSetter(key, ['expressionValue', 'model', 'templateOptions', 'validation']),
+            expressionValueSetter: evalExpressionValueSetter(key, ['expressionValue', 'model', 'templateOptions', 'validation', 'field']),
           };
         }
       }

--- a/src/core/src/services/formly.form.expression.ts
+++ b/src/core/src/services/formly.form.expression.ts
@@ -45,7 +45,7 @@ export class FormlyFormExpression {
         evalExpression(
           expressionProperties[key].expressionValueSetter,
           { field },
-          [expressionValue, model, field.templateOptions, field.validation],
+          [expressionValue, model, field.templateOptions, field.validation, field],
         );
 
         const validators = FORMLY_VALIDATORS.map(v => `templateOptions.${v}`);


### PR DESCRIPTION
**What kind of change does this PR introduce? feature**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/721)
<!-- Reviewable:end -->
