### PR TITLE
fix(bootstrap): don't render label when the templateOption is not set

### DIFF
--- a/src/ui-bootstrap/src/wrappers/label.ts
+++ b/src/ui-bootstrap/src/wrappers/label.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
   selector: 'formly-wrapper-label',
   template: `
-    <label [attr.for]="id" class="form-control-label control-label">
+    <label [attr.for]="id" class="form-control-label control-label" *ngIf="to.label">
       {{ to.label }}
       {{ to.required ? '*' : '' }}
     </label>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Small fix to not display the `<label>` element when the parameter is not set in the `templateOptions` property.

**What is the current behavior? (You can also link to an open issue here)**

Currently the element is displayed even when the value is empty, this leads to some extra empty space between the inputs. 

**What is the new behavior (if this is a feature change)?**

After this PR the white space is not displayed anymore.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/734)
<!-- Reviewable:end -->
