### PR TITLE
fix(FormlyFormExpression): ensure toggling formControl when key contains array syntax

### DIFF
--- a/src/core/src/components/formly.form.spec.ts
+++ b/src/core/src/components/formly.form.spec.ts
@@ -197,19 +197,19 @@ describe('Formly Form Component', () => {
     it('should hide/display field using a function with nested field key', fakeAsync(() => {
       const form = new FormGroup({});
       testComponentInputs.form = form;
-      testComponentInputs.model = { address: { city: '' } };
-      field.key = 'address.city';
-      field.hideExpression = '!(model.address && model.address.city === "agadir")';
+      testComponentInputs.model = { address: [{ city: '' }] };
+      field.key = 'address[0].city';
+      field.hideExpression = '!(model.address && model.address[0] && model.address[0].city === "agadir")';
 
       const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>');
       tick(1);
-      expect(form.get('address.city')).toBeNull();
+      expect(form.get('address.0.city')).toBeNull();
 
-      testComponentInputs.model.address.city = 'agadir';
+      testComponentInputs.model.address[0].city = 'agadir';
       fixture.detectChanges();
       tick(1);
-      expect(form.get('address.city')).not.toBeNull();
-      expect(form.get('address.city').value).toEqual('agadir');
+      expect(form.get('address.0.city')).not.toBeNull();
+      expect(form.get('address.0.city').value).toEqual('agadir');
     }));
 
     it('should hide/display child fields when field has empty key', fakeAsync(() => {

--- a/src/core/src/utils.ts
+++ b/src/core/src/utils.ts
@@ -9,31 +9,31 @@ export function getFieldId(formId: string, options: FormlyFieldConfig, index: st
 
 export function getKeyPath(field: {key?: string|string[], fieldGroup?: any, fieldArray?: any}): (string|number)[] {
   /* We store the keyPath in the field for performance reasons. This function will be called frequently. */
-  if ((<any> field)['_formlyKeyPath'] !== undefined) {
-    return (<any> field)['_formlyKeyPath'];
-  }
-  let keyPath: (string|number)[] = [];
-  if (field.key) {
-    /* Also allow for an array key, hence the type check  */
-    let pathElements = typeof field.key === 'string' ? field.key.split('.') : field.key;
-    for (let pathElement of pathElements) {
-      if (typeof pathElement === 'string') {
-        /* replace paths of the form names[2] by names.2, cfr. angular formly */
-        pathElement = pathElement.replace(/\[(\w+)\]/g, '.$1');
-        keyPath = keyPath.concat(pathElement.split('.'));
-      } else {
-        keyPath.push(pathElement);
+  if (!(<any> field)['_formlyKeyPath']) {
+    let keyPath: (string|number)[] = [];
+    if (field.key) {
+      /* Also allow for an array key, hence the type check  */
+      let pathElements = typeof field.key === 'string' ? field.key.split('.') : field.key;
+      for (let pathElement of pathElements) {
+        if (typeof pathElement === 'string') {
+          /* replace paths of the form names[2] by names.2, cfr. angular formly */
+          pathElement = pathElement.replace(/\[(\w+)\]/g, '.$1');
+          keyPath = keyPath.concat(pathElement.split('.'));
+        } else {
+          keyPath.push(pathElement);
+        }
+      }
+      for (let i = 0; i < keyPath.length; i++) {
+        let pathElement = keyPath[i];
+        if (typeof pathElement === 'string' && stringIsInteger(pathElement))  {
+          keyPath[i] = parseInt(pathElement);
+        }
       }
     }
-    for (let i = 0; i < keyPath.length; i++) {
-      let pathElement = keyPath[i];
-      if (typeof pathElement === 'string' && stringIsInteger(pathElement))  {
-        keyPath[i] = parseInt(pathElement);
-      }
-    }
+    (<any> field)['_formlyKeyPath'] = keyPath;
   }
-  (<any> field)['_formlyKeyPath'] = keyPath;
-  return keyPath;
+
+  return (<any> field)['_formlyKeyPath'].slice(0);
 }
 
 function stringIsInteger(str: string) {


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/735)
<!-- Reviewable:end -->
