### PR TITLE
feat(core): allow rendering extra attributes

### DIFF
--- a/src/core/src/components/formly.attributes.spec.ts
+++ b/src/core/src/components/formly.attributes.spec.ts
@@ -35,6 +35,9 @@ describe('FormlyAttributes Component', () => {
         expect(elm.getAttribute('name')).toBe('title-name');
         expect(elm.getAttribute('id')).toBe('title-id');
         expect(elm.getAttribute('aria-describedby')).toBe('title-id-message');
+        // using attributes option
+        expect(elm.getAttribute('min')).toEqual('5');
+        expect(elm.getAttribute('max')).toEqual('10');
         expect(fixture.componentInstance.field.focus).toBeFalsy();
       });
 
@@ -98,6 +101,10 @@ class TestComponent {
       'aria-describedby': true,
       tabindex: 5,
       step: 2,
+      attributes: {
+        min: 5,
+        max: 10,
+      },
     },
   };
 }

--- a/src/core/src/components/formly.attributes.ts
+++ b/src/core/src/components/formly.attributes.ts
@@ -33,6 +33,13 @@ export class FormlyAttributes implements OnChanges {
           this.elementRef.nativeElement, attr, this.getPropValue(this.field, attr),
         ));
 
+      if (this.field.templateOptions.attributes) {
+        const attributes = this.field.templateOptions.attributes;
+        Object.keys(attributes).forEach(name => this.renderer.setAttribute(
+          this.elementRef.nativeElement, name, attributes[name] as string,
+        ));
+      }
+
       this.statements
         .filter(statement => this.canApplyRender(fieldChanges, statement))
         .forEach(statement => this.renderer.listen(

--- a/src/core/src/components/formly.field.config.ts
+++ b/src/core/src/components/formly.field.config.ts
@@ -168,6 +168,7 @@ export interface FormlyTemplateOptions {
   pattern?: string|RegExp;
   required?: boolean;
   tabindex?: number;
+  attributes?: { [key: string]: string|number };
   step?: number;
   focus?: (field: FormlyFieldConfig, formControl: AbstractControl) => void;
   blur?: (field: FormlyFieldConfig, formControl: AbstractControl) => void;


### PR DESCRIPTION
**What kind of change does this PR introduce? feature**

**What is the current behavior? (You can also link to an open issue here)**
There is no way to allow rendering extra html attribures

**What is the new behavior (if this is a feature change)?**
Introduce `attributes` options which allow users to specify which option in `templateOption` can be used as an attribute.

for example for range type we can use:
```ts
{
  key: 'age',
 type: 'input',
  templateOptions: {
      attributes: {
        min: 5,
        max: 10,
      },
  }
}
```

we can also set those attributes globally in formly declaration:

```ts
    FormlyModule.forRoot({
      types: [
        {
          name: 'range',
          extends: 'input',
          defaultOptions: {
            templateOptions: {
              type: 'range',
              attributes: {
                min: 5,
                max: 10,
              },
            },
          },
        },
      ],
    }),
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/736)
<!-- Reviewable:end -->
