### PR TITLE
fix(core): only read attributes property if templateOptions are set

### DIFF
--- a/src/core/src/components/formly.attributes.spec.ts
+++ b/src/core/src/components/formly.attributes.spec.ts
@@ -60,6 +60,23 @@ describe('FormlyAttributes Component', () => {
         expect(elm.getAttribute('step')).toBe('');
         expect(fixture.componentInstance.field.focus).toBeTruthy();
       });
+
+      it('should not fail without templateOptions', () => {
+          const fixture = createTestComponent('<input type="text" [formlyAttributes]="field">');
+          const elm = getFormlyAttributesElement(fixture.nativeElement);
+
+          fixture.componentInstance.field = {
+              key: 'title',
+              focus: true,
+          };
+
+          fixture.detectChanges();
+
+          expect(elm.getAttribute('tabindex')).toBe('');
+          expect(elm.getAttribute('step')).toBe('');
+          expect(fixture.componentInstance.field.focus).toBeTruthy();
+      });
+
   });
 
   describe('focus the element', () => {

--- a/src/core/src/components/formly.attributes.ts
+++ b/src/core/src/components/formly.attributes.ts
@@ -33,7 +33,7 @@ export class FormlyAttributes implements OnChanges {
           this.elementRef.nativeElement, attr, this.getPropValue(this.field, attr),
         ));
 
-      if (this.field.templateOptions.attributes) {
+      if (this.field.templateOptions && this.field.templateOptions.attributes) {
         const attributes = this.field.templateOptions.attributes;
         Object.keys(attributes).forEach(name => this.renderer.setAttribute(
           this.elementRef.nativeElement, name, attributes[name] as string,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Running our project with the latest version of ngx-formly resulted in the error below, because it tried to read the `attributes` property from `templateOptions` which does not always exist.

```
TypeError: Cannot read property 'attributes' of undefined
     at FormlyAttributes.ngOnChanges (webpack:///src/core/src/components/formly.attributes.ts:26:43 <- .config/karma-shim.js:32185:14434)
     at checkAndUpdateDirectiveInline (webpack:///node_modules/@angular/core/@angular/core.es5.js:10840:0 <- .config/karma-shim.js:11305:19)
     at checkAndUpdateNodeInline (webpack:///node_modules/@angular/core/@angular/core.es5.js:12341:0 <- .config/karma-shim.js:12806:20)
     at checkAndUpdateNode (webpack:///node_modules/@angular/core/@angular/core.es5.js:12284:0 <- .config/karma-shim.js:12749:16)
     at debugCheckAndUpdateNode (webpack:///node_modules/@angular/core/@angular/core.es5.js:13141:21 <- .config/karma-shim.js:13606:59)
     at debugCheckDirectivesFn (webpack:///node_modules/@angular/core/@angular/core.es5.js:13082:0 <- .config/karma-shim.js:13547:13)
     at Object.eval [as updateDirectives] (ng:///DynamicTestModule/TestComponent.ngfactory.js:23:5)
     at Object.debugUpdateDirectives [as updateDirectives] (webpack:///node_modules/@angular/core/@angular/core.es5.js:13067:0 <- .config/karma-shim.js:13532:21)
     at checkAndUpdateView (webpack:///node_modules/@angular/core/@angular/core.es5.js:12251:0 <- .config/karma-shim.js:12716:14)
     at callViewAction (webpack:///node_modules/@angular/core/@angular/core.es5.js:12599:0 <- .config/karma-shim.js:13064:21)
     at execComponentViewsAction (webpack:///node_modules/@angular/core/@angular/core.es5.js:12531:0 <- .config/karma-shim.js:12996:13)
     at checkAndUpdateView (webpack:///node_modules/@angular/core/@angular/core.es5.js:12257:0 <- .config/karma-shim.js:12722:5)
     at callWithDebugContext (webpack:///node_modules/@angular/core/@angular/core.es5.js:13467:25 <- .config/karma-shim.js:13932:42)
     at Object.debugCheckAndUpdateView [as checkAndUpdateView] (webpack:///node_modules/@angular/core/@angular/core.es5.js:13007:0 <- .config/karma-shim.js:13472:12)
     at ViewRef_.detectChanges (webpack:///node_modules/@angular/core/@angular/core.es5.js:10174:0 <- .config/karma-shim.js:10639:18)
     at ComponentFixture._tick (webpack:///node_modules/@angular/core/@angular/core/testing.es5.js:182:0 <- .config/karma-shim.js:21998:32)
     at webpack:///node_modules/@angular/core/@angular/core/testing.es5.js:196:41 <- .config/karma-shim.js:22012:49
     at ZoneDelegate.invoke (webpack:///node_modules/zone.js/dist/zone.js:392:0 <- .config/karma-shim.js:70918:26)
     at ProxyZoneSpec.onInvoke (webpack:///node_modules/zone.js/dist/proxy.js:79:0 <- .config/karma-shim.js:73819:39)
     at ZoneDelegate.invoke (webpack:///node_modules/zone.js/dist/zone.js:391:0 <- .config/karma-shim.js:70917:32)
     at Object.onInvoke (webpack:///node_modules/@angular/core/@angular/core.es5.js:3890:0 <- .config/karma-shim.js:4355:33)
     at ZoneDelegate.invoke (webpack:///node_modules/zone.js/dist/zone.js:391:0 <- .config/karma-shim.js:70917:32)
     at Zone.run (webpack:///node_modules/zone.js/dist/zone.js:142:0 <- .config/karma-shim.js:70668:43)
     at NgZone.run (webpack:///node_modules/@angular/core/@angular/core.es5.js:3821:42 <- .config/karma-shim.js:4286:69)
     at ComponentFixture.detectChanges (webpack:///node_modules/@angular/core/@angular/core/testing.es5.js:196:0 <- .config/karma-shim.js:22012:25)
     at UserContext.<anonymous> (webpack:///src/core/src/components/formly.attributes.spec.ts:62:0 <- .config/karma-shim.js:74622:21)
     at ZoneDelegate.invoke (webpack:///node_modules/zone.js/dist/zone.js:392:0 <- .config/karma-shim.js:70918:26)
     at ProxyZoneSpec.onInvoke (webpack:///node_modules/zone.js/dist/proxy.js:79:0 <- .config/karma-shim.js:73819:39)
     at ZoneDelegate.invoke (webpack:///node_modules/zone.js/dist/zone.js:391:0 <- .config/karma-shim.js:70917:32)
     at Zone.run (webpack:///node_modules/zone.js/dist/zone.js:142:0 <- .config/karma-shim.js:70668:43)
     at UserContext.<anonymous> (webpack:///node_modules/zone.js/dist/jasmine-patch.js:104:0 <- .config/karma-shim.js:74027:34)
     at ZoneQueueRunner.jasmine.QueueRunner.ZoneQueueRunner.execute (webpack:///node_modules/zone.js/dist/jasmine-patch.js:132:0 <- .config/karma-shim.js:74055:42)
     at ZoneDelegate.invokeTask (webpack:///node_modules/zone.js/dist/zone.js:425:0 <- .config/karma-shim.js:70951:31)
     at Zone.runTask (webpack:///node_modules/zone.js/dist/zone.js:192:0 <- .config/karma-shim.js:70718:47)
     at drainMicroTaskQueue (webpack:///node_modules/zone.js/dist/zone.js:602:0 <- .config/karma-shim.js:71128:35)
     at <anonymous>
```

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/744)
<!-- Reviewable:end -->
