### PR TITLE
feat(core): allow binding Observables to select options

### DIFF
--- a/demo/src/app/examples/examples.component.ts
+++ b/demo/src/app/examples/examples.component.ts
@@ -62,6 +62,7 @@ export class ExamplesComponent {
     ]},
     { title: 'Other', links: [
       { href: './other/cascaded-select', text: 'Cascaded Select' },
+      { href: './other/observable-select', text: 'Bind Observable to Select' },
       { href: './other/advanced-layout-flex', text: 'Advanced Layout (Flex)' },
       { href: './other/nested-formly-forms', text: 'Nested Forms (fieldGroup wrapper)' },
       { href: './other/button', text: 'Button Type' },

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -62,6 +62,7 @@ import { ExamplesComponent } from './examples.component';
         // Other
         { path: 'other', children: [
           { path: 'cascaded-select', loadChildren: './other/cascaded-select/config.module#ConfigModule' },
+          { path: 'observable-select', loadChildren: './other/observable-select/config.module#ConfigModule' },
           { path: 'advanced-layout-flex', loadChildren: './other/advanced-layout-flex/config.module#ConfigModule' },
           { path: 'nested-formly-forms', loadChildren: './other/nested-formly-forms/config.module#ConfigModule' },
           { path: 'button', loadChildren: './other/button/config.module#ConfigModule' },

--- a/demo/src/app/examples/other/observable-select/app.component.html
+++ b/demo/src/app/examples/other/observable-select/app.component.html
@@ -1,0 +1,5 @@
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form">
+    <button type="submit" class="btn btn-primary submit-button" [disabled]="!form.valid">Submit</button>
+  </formly-form>
+</form>

--- a/demo/src/app/examples/other/observable-select/app.component.ts
+++ b/demo/src/app/examples/other/observable-select/app.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnDestroy } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+import { Subject } from 'rxjs/Subject';
+import { takeUntil } from 'rxjs/operators/takeUntil';
+import { tap } from 'rxjs/operators/tap';
+import { DataService } from './data.service';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent implements OnDestroy {
+  onDestroy$ = new Subject<void>();
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'sport',
+      type: 'select',
+      templateOptions: {
+        label: 'Sport',
+        options: this.dataService.getSports(),
+        valueProp: 'id',
+        labelProp: 'name',
+      },
+    }
+  ];
+
+  constructor(private dataService: DataService) {}
+
+  submit() {
+    alert(JSON.stringify(this.model));
+  }
+
+  ngOnDestroy(): void {
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
+  }
+}

--- a/demo/src/app/examples/other/observable-select/app.module.ts
+++ b/demo/src/app/examples/other/observable-select/app.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
+
+import { AppComponent } from './app.component';
+import { DataService } from './data.service';
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormlyBootstrapModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [
+    AppComponent,
+  ],
+  providers: [DataService]
+})
+export class AppModule { }

--- a/demo/src/app/examples/other/observable-select/config.module.ts
+++ b/demo/src/app/examples/other/observable-select/config.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [{
+            title: 'Bind Observables to Select',
+            description: ``,
+            component: AppComponent,
+            files: [
+              { file: 'app.component.html', content: require('!!prismjs-loader?lang=html!./app.component.html') },
+              { file: 'app.component.ts', content: require('!!prismjs-loader?lang=typescript!./app.component.ts') },
+              { file: 'app.module.ts', content: require('!!prismjs-loader?lang=typescript!./app.module.ts') },
+              { file: 'data.service.ts', content: require('!!prismjs-loader?lang=typescript!./data.service.ts') },
+            ],
+          }],
+        },
+      },
+    ]),
+  ],
+})
+export class ConfigModule { }

--- a/demo/src/app/examples/other/observable-select/data.service.ts
+++ b/demo/src/app/examples/other/observable-select/data.service.ts
@@ -12,5 +12,4 @@ export class DataService {
     getSports(): Observable<any[]> {
         return of(this.sports);
     }
-
 }

--- a/demo/src/app/examples/other/observable-select/data.service.ts
+++ b/demo/src/app/examples/other/observable-select/data.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { of } from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class DataService {
+    sports = [
+        { id: '1', name: 'Soccer' },
+        { id: '2', name: 'Basketball' },
+    ];
+
+    getSports(): Observable<any[]> {
+        return of(this.sports);
+    }
+
+}

--- a/src/core/src/components/formly.field.config.ts
+++ b/src/core/src/components/formly.field.config.ts
@@ -2,6 +2,7 @@ import { FormGroup, AbstractControl, FormGroupDirective, NgForm, FormArray } fro
 import { Subject } from 'rxjs/Subject';
 import { Field } from '../templates/field';
 import { TemplateManipulators } from '../services/formly.config';
+import { Observable } from 'rxjs/Observable';
 
 export interface FormlyFieldConfig {
   /**
@@ -156,7 +157,7 @@ export interface FormlyTemplateOptions {
   label?: string;
   placeholder?: string;
   disabled?: boolean;
-  options?: any[];
+  options?: any[] | Observable<any[]>;
   rows?: number;
   cols?: number;
   description?: string;

--- a/src/ui-bootstrap/src/types/multicheckbox.ts
+++ b/src/ui-bootstrap/src/types/multicheckbox.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormGroup, FormControl, AbstractControl } from '@angular/forms';
 import { FieldType, FormlyFieldConfig } from '@ngx-formly/core';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
   selector: 'formly-field-multicheckbox',
@@ -20,15 +21,19 @@ import { FieldType, FormlyFieldConfig } from '@ngx-formly/core';
 })
 export class FormlyFieldMultiCheckbox extends FieldType {
   static createControl(model: any, field: FormlyFieldConfig): AbstractControl {
-    let controlGroupConfig = field.templateOptions.options.reduce((previous, option) => {
-      previous[option.key] = new FormControl(model ? model[option.key] : undefined);
-      return previous;
-    }, {});
+    if (!(field.templateOptions.options instanceof Observable)) {
+      let controlGroupConfig = field.templateOptions.options.reduce((previous, option) => {
+        previous[option.key] = new FormControl(model ? model[option.key] : undefined);
+        return previous;
+      }, {});
 
-    return new FormGroup(
-      controlGroupConfig,
-      field.validators ? field.validators.validation : undefined,
-      field.asyncValidators ? field.asyncValidators.validation : undefined,
-    );
+      return new FormGroup(
+        controlGroupConfig,
+        field.validators ? field.validators.validation : undefined,
+        field.asyncValidators ? field.asyncValidators.validation : undefined,
+      );
+    } else {
+      console.error('You cannot pass an Observable to a multicheckbox yet.');
+    }
   }
 }

--- a/src/ui-bootstrap/src/types/multicheckbox.ts
+++ b/src/ui-bootstrap/src/types/multicheckbox.ts
@@ -33,7 +33,7 @@ export class FormlyFieldMultiCheckbox extends FieldType {
         field.asyncValidators ? field.asyncValidators.validation : undefined,
       );
     } else {
-      console.error('You cannot pass an Observable to a multicheckbox yet.');
+      throw new Error(`[Formly Error] You cannot pass an Observable to a multicheckbox yet.`);
     }
   }
 }

--- a/src/ui-bootstrap/src/types/select.spec.ts
+++ b/src/ui-bootstrap/src/types/select.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed, ComponentFixture, fakeAsync, tick, async } from '@angular/core/testing';
+import { createGenericTestComponent } from '../../../core/src/test-utils';
+import { By } from '@angular/platform-browser';
+
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { FormlyModule, FormlyFormBuilder } from '../../../core';
+import { FormGroup, FormBuilder } from '@angular/forms';
+import { FormlyFieldSelect } from './select';
+import { FormlyForm } from '../../../core';
+import { of } from 'rxjs/observable/of';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+
+let testComponentInputs;
+
+describe('ui-bootstrap: Formly Field Select Component', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [FormlyModule.forRoot({
+      types: [
+        {
+          name: 'select',
+          component: FormlyFieldSelect,
+        }
+      ]
+    })]});
+  });
+
+  describe('options', () => {
+    beforeEach(() => {
+      testComponentInputs = {
+        form: new FormGroup({}),
+        options: {},
+        model: {},
+      };
+    });
+
+
+    it('should correctly bind to a static array of data', () => {
+        testComponentInputs.fields = [{
+            key: 'sportId',
+            type: 'select',
+            templateOptions: {
+                options: [
+                    { id: '1', name: 'Soccer' },
+                    { id: '2', name: 'Basketball' },
+                ],
+                valueProp: 'id',
+                labelProp: 'name',
+            }
+        }];
+
+        const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+        
+        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(2);
+    });
+
+    it('should correctly bind to an Observable', async(() => {
+      const sports$ = of([
+        { id: '1', name: 'Soccer' },
+        { id: '2', name: 'Basketball' },
+      ]);
+
+      testComponentInputs.fields = [{
+          key: 'sportId',
+          type: 'select',
+          templateOptions: {
+              options: sports$,
+              valueProp: 'id',
+              labelProp: 'name',
+          }
+      }];
+
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      
+      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(2);
+    }));
+
+  });
+
+});
+
+@Component({selector: 'formly-form-test', template: '', entryComponents: []})
+class TestComponent {
+  @ViewChild(FormlyForm) formlyForm: FormlyForm;
+
+  fields = testComponentInputs.fields;
+  form = testComponentInputs.form;
+  model = testComponentInputs.model || {};
+  options = testComponentInputs.options;
+}

--- a/src/ui-bootstrap/src/types/select.ts
+++ b/src/ui-bootstrap/src/types/select.ts
@@ -82,7 +82,7 @@ export class FormlyFieldSelect extends FieldType {
       return of(options);
     } else {
       // return observable directly
-      return this.to.options || of([]);
+      return this.to.options;
     }
   }
 }

--- a/src/ui-bootstrap/src/types/select.ts
+++ b/src/ui-bootstrap/src/types/select.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 export class SelectOption {
   label: string;
@@ -23,7 +25,7 @@ export class SelectOption {
       [class.is-invalid]="showError"
       [multiple]="true"
       [formlyAttributes]="field">
-        <ng-container *ngFor="let item of selectOptions">
+        <ng-container *ngFor="let item of selectOptions | async">
          <optgroup *ngIf="item.group" label="{{item.label}}">
             <option *ngFor="let child of item.group" [value]="child[valueProp]" [disabled]="child.disabled">
               {{ child[labelProp] }}
@@ -39,7 +41,7 @@ export class SelectOption {
         [class.is-invalid]="showError"
         [formlyAttributes]="field">
         <option *ngIf="to.placeholder" value="">{{ to.placeholder }}</option>
-        <ng-container *ngFor="let item of selectOptions">
+        <ng-container *ngFor="let item of selectOptions | async">
           <optgroup *ngIf="item.group" label="{{item.label}}">
             <option *ngFor="let child of item.group" [value]="child[valueProp]" [disabled]="child.disabled">
               {{ child[labelProp] }}
@@ -56,26 +58,31 @@ export class FormlyFieldSelect extends FieldType {
   get valueProp(): string { return this.to.valueProp || 'value'; }
   get groupProp(): string { return this.to.groupProp || 'group'; }
 
-  get selectOptions() {
-    const options: SelectOption[] = [],
-      groups: { [key: string]: SelectOption[] } = {};
+  get selectOptions(): Observable<any[]> {
+    if (!(this.to.options instanceof Observable)) {
+      const options: SelectOption[] = [],
+        groups: { [key: string]: SelectOption[] } = {};
 
-    this.to.options.map((option: SelectOption) => {
-      if (!option[this.groupProp]) {
-        options.push(option);
-      } else {
-        if (groups[option[this.groupProp]]) {
-          groups[option[this.groupProp]].push(option);
+      this.to.options.map((option: SelectOption) => {
+        if (!option[this.groupProp]) {
+          options.push(option);
         } else {
-          groups[option[this.groupProp]] = [option];
-          options.push({
-            label: option[this.groupProp],
-            group: groups[option[this.groupProp]],
-          });
+          if (groups[option[this.groupProp]]) {
+            groups[option[this.groupProp]].push(option);
+          } else {
+            groups[option[this.groupProp]] = [option];
+            options.push({
+              label: option[this.groupProp],
+              group: groups[option[this.groupProp]],
+            });
+          }
         }
-      }
-    });
+      });
 
-    return options;
+      return of(options);
+    } else {
+      // return observable directly
+      return this.to.options || of([]);
+    }
   }
 }

--- a/src/ui-material/src/types/multicheckbox.ts
+++ b/src/ui-material/src/types/multicheckbox.ts
@@ -2,6 +2,7 @@ import { Component, AfterViewInit, Renderer2 } from '@angular/core';
 import { FormGroup, FormControl, AbstractControl } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { FieldType } from './field';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
   selector: 'formly-field-mat-multicheckbox',
@@ -13,16 +14,20 @@ import { FieldType } from './field';
 })
 export class FormlyFieldMultiCheckbox extends FieldType implements AfterViewInit {
   static createControl(model: any, field: FormlyFieldConfig): AbstractControl {
-    let controlGroupConfig = field.templateOptions.options.reduce((previous, option) => {
-      previous[option.key] = new FormControl(model ? model[option.key] : undefined);
-      return previous;
-    }, {});
+    if (!(field.templateOptions.options instanceof Observable)) {
+      let controlGroupConfig = field.templateOptions.options.reduce((previous, option) => {
+        previous[option.key] = new FormControl(model ? model[option.key] : undefined);
+        return previous;
+      }, {});
 
-    return new FormGroup(
-      controlGroupConfig,
-      field.validators ? field.validators.validation : undefined,
-      field.asyncValidators ? field.asyncValidators.validation : undefined,
-    );
+      return new FormGroup(
+        controlGroupConfig,
+        field.validators ? field.validators.validation : undefined,
+        field.asyncValidators ? field.asyncValidators.validation : undefined,
+      );
+    } else {
+      console.error('You cannot pass an Observable to a multicheckbox yet.');
+    }
   }
 
   constructor(private renderer?: Renderer2) {

--- a/src/ui-material/src/types/multicheckbox.ts
+++ b/src/ui-material/src/types/multicheckbox.ts
@@ -26,7 +26,7 @@ export class FormlyFieldMultiCheckbox extends FieldType implements AfterViewInit
         field.asyncValidators ? field.asyncValidators.validation : undefined,
       );
     } else {
-      console.error('You cannot pass an Observable to a multicheckbox yet.');
+      throw new Error(`[Formly Error] You cannot pass an Observable to a multicheckbox yet.`);
     }
   }
 

--- a/src/ui-material/src/types/select.ts
+++ b/src/ui-material/src/types/select.ts
@@ -69,7 +69,7 @@ export class FormlyFieldSelect extends FieldType implements OnInit {
       return of(options);
     } else {
       // return observable directly
-      return this.to.options || of([]);
+      return this.to.options;
     }
   }
 }

--- a/src/ui-material/src/types/select.ts
+++ b/src/ui-material/src/types/select.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatSelect } from '@angular/material/select';
 import { FieldType } from './field';
+import { of } from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
 
 export class SelectOption {
   label: string;
@@ -25,7 +27,7 @@ export class SelectOption {
       [multiple]="to.multiple"
       (selectionChange)="to.change && to.change(field, formControl)"
       [errorStateMatcher]="errorStateMatcher">
-      <ng-container *ngFor="let item of selectOptions">
+      <ng-container *ngFor="let item of selectOptions | async">
         <mat-optgroup *ngIf="item.group" label="{{item.label}}">
           <mat-option *ngFor="let child of item.group" [value]="child[valueProp]" [disabled]="child.disabled">
             {{ child[labelProp] }}
@@ -43,26 +45,31 @@ export class FormlyFieldSelect extends FieldType implements OnInit {
   get valueProp(): string { return this.to.valueProp || 'value'; }
   get groupProp(): string { return this.to.groupProp || 'group'; }
 
-  get selectOptions() {
-    const options: SelectOption[] = [],
-      groups: { [key: string]: SelectOption[] } = {};
+  get selectOptions(): Observable<any[]> {
+    if (!(this.to.options instanceof Observable)) {
+      const options: SelectOption[] = [],
+        groups: { [key: string]: SelectOption[] } = {};
 
-    this.to.options.map((option: SelectOption) => {
-      if (!option[this.groupProp]) {
-        options.push(option);
-      } else {
-        if (groups[option[this.groupProp]]) {
-          groups[option[this.groupProp]].push(option);
+      this.to.options.map((option: SelectOption) => {
+        if (!option[this.groupProp]) {
+          options.push(option);
         } else {
-          groups[option[this.groupProp]] = [option];
-          options.push({
-            label: option[this.groupProp],
-            group: groups[option[this.groupProp]],
-          });
+          if (groups[option[this.groupProp]]) {
+            groups[option[this.groupProp]].push(option);
+          } else {
+            groups[option[this.groupProp]] = [option];
+            options.push({
+              label: option[this.groupProp],
+              group: groups[option[this.groupProp]],
+            });
+          }
         }
-      }
-    });
+      });
 
-    return options;
+      return of(options);
+    } else {
+      // return observable directly
+      return this.to.options || of([]);
+    }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature.

**What is the current behavior? (You can also link to an open issue here)**

See #693

**What is the new behavior (if this is a feature change)?**

Now it's possible to bind `Observable` streams to the `options` property of `type: 'select'` fields.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Other information**:

Also added a new demo example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/772)
<!-- Reviewable:end -->
