### PR TITLE
fix(core): `addFormControl` apply patchValue only for FormControl instance.

### DIFF
--- a/src/core/src/services/formly.form.builder.spec.ts
+++ b/src/core/src/services/formly.form.builder.spec.ts
@@ -38,19 +38,20 @@ describe('FormlyFormBuilder service', () => {
       },
       {
         key: 'fieldGroup',
-        fieldGroup: [],
-        formControl: new FormGroup({}),
+        type: 'input',
+        formControl: new FormGroup({ aa: new FormControl('aa') }),
       },
       {
         key: 'fieldArray',
-        fieldGroup: [],
-        formControl: new FormArray([]),
-        fieldArray: {},
+        type: 'input',
+        formControl: new FormArray([new FormControl('aa')]),
       },
     ];
 
-    builder.buildForm(form, fields, { test: 'test', fieldGroup: { test: 'ddd' }, fieldArray: {} }, {});
+    builder.buildForm(form, fields, { test: 'test' }, {});
     expect(fields[0].formControl.value).toEqual('test');
+    expect(fields[1].formControl.value).toEqual({ aa: 'aa' });
+    expect(fields[2].formControl.value).toEqual(['aa']);
   });
 
   it('should not re-build field', () => {

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -242,6 +242,7 @@ export class FormlyFormBuilder {
       if (
         !(isNullOrUndefined(control.value) && isNullOrUndefined(model[path]))
         && control.value !== model[path]
+        && control instanceof FormControl
       ) {
         control.patchValue(model[path]);
       }


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/799)
<!-- Reviewable:end -->
