### PR TITLE
test(FormlyFormExpression): add test for service

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "form library"
   ],
   "license": "MIT",
-  "description": "@ngx-formly i@angular/animationss an Angular 2 module which has a Components to help customize and render JavaScript/JSON configured forms. The formly-form Component and the FormlyConfig service are very powerful and bring unmatched maintainability to your application's forms.",
+  "description": "@ngx-formly is an Angular 2 module which has Components to help customize and render JavaScript/JSON configured forms. The `formly-form` Component and the FormlyConfig service are very powerful and bring unmatched maintainability to your application's forms.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/formly-js/ngx-formly.git"

--- a/src/core/src/services/formly.form.builder.spec.ts
+++ b/src/core/src/services/formly.form.builder.spec.ts
@@ -2,12 +2,16 @@ import { FormlyFormBuilder, FormlyConfig, FormlyFieldConfig } from '../core';
 import { FormGroup, Validators, FormControl, FormArray } from '@angular/forms';
 import { Component } from '@angular/core';
 import { FormlyFormExpression } from './formly.form.expression';
+import { MockComponent } from '../test-utils';
 
 describe('FormlyFormBuilder service', () => {
-  let builder: FormlyFormBuilder,
-    form: FormGroup,
-    field: FormlyFieldConfig;
+  let builder: FormlyFormBuilder;
+  let form: FormGroup;
+  let field: FormlyFieldConfig;
+  let TestComponent: Component;
+
   beforeEach(() => {
+    TestComponent = MockComponent({ selector: 'formly-test-cmp' });
     form = new FormGroup({});
     builder = new FormlyFormBuilder(
       new FormlyConfig([{
@@ -439,11 +443,7 @@ describe('FormlyFormBuilder service', () => {
   });
 });
 
-@Component({selector: 'formly-test-cmp', template: '', entryComponents: []})
-class TestComponent {
-}
-
-class TestComponentThatCreatesControl {
+export class TestComponentThatCreatesControl {
 
   createControl(model, field) {
     return new FormControl('created by component');

--- a/src/core/src/services/formly.form.expression.spec.ts
+++ b/src/core/src/services/formly.form.expression.spec.ts
@@ -1,180 +1,31 @@
-import { FormlyConfig } from './formly.config';
-import { FormlyFieldConfig, FormlyFormOptions } from '../core';
 import { AbstractControl, FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Component } from '@angular/core';
+import { MockComponent } from '../test-utils';
+
+import { FormlyConfig } from './formly.config';
+import { FormlyFieldConfig, FormlyFormBuilder, FormlyFormOptions, FormlyForm } from '../core';
 import { evalStringExpression, evalExpressionValueSetter, FORMLY_VALIDATORS, getKeyPath, isFunction, isObject } from './../utils';
 
 import { FormlyFormExpression } from './formly.form.expression';
 
-function registerFormControls(form: FormGroup | FormArray, fields: FormlyFieldConfig[], model: any, options: FormlyFormOptions) {
-  fields.forEach((field, index) => {
-    initFieldOptions(field);
-    initFieldExpression(field, model, options);
-    initFieldValidation(field);
-
-    if (field.key && field.type) {
-      const paths = getKeyPath({ key: field.key });
-      let rootForm = form, rootModel = model;
-      paths.forEach((path, index) => {
-        // FormGroup/FormArray only allow string value for path
-        const formPath = path.toString();
-        // is last item
-        if (index === paths.length - 1) {
-          addFormControl(rootForm, field, rootModel, formPath);
-        } else {
-          let nestedForm = rootForm.get(formPath) as FormGroup;
-          if (!nestedForm) {
-            nestedForm = new FormGroup({});
-            addControl(rootForm, formPath, nestedForm);
-          }
-          if (!rootModel[path]) {
-            rootModel[path] = typeof path === 'string' ? {} : [];
-          }
-
-          rootForm = nestedForm;
-          rootModel = rootModel[path];
-        }
-      });
-    }
-  });
-}
-
-function initFieldOptions(field: FormlyFieldConfig) {
-  field.templateOptions = field.templateOptions || {};
-  if (field.type) {
-    if (field.key) {
-      field.templateOptions = Object.assign({
-        label: '',
-        placeholder: '',
-        focus: false,
-      }, field.templateOptions);
-    }
-  }
-}
-
-function initFieldExpression(field: FormlyFieldConfig, model: any, options: FormlyFormOptions) {
-  if (field.expressionProperties) {
-    for (let key in field.expressionProperties as any) {
-      if (typeof field.expressionProperties[key] === 'string' || isFunction(field.expressionProperties[key])) {
-        // cache built expression
-        field.expressionProperties[key] = {
-          expression: isFunction(field.expressionProperties[key]) ? field.expressionProperties[key] : evalStringExpression(field.expressionProperties[key], ['model', 'formState']),
-          expressionValueSetter: evalExpressionValueSetter(key, ['expressionValue', 'model', 'templateOptions', 'validation', 'field']),
-        };
-      }
-    }
-  }
-
-  if (field.hideExpression) {
-    if (typeof field.hideExpression === 'string') {
-      // cache built expression
-      field.hideExpression = evalStringExpression(field.hideExpression, ['model', 'formState']);
-    }
-  }
-}
-
-function initFieldValidation(field: FormlyFieldConfig) {
-  let validators: any = [];
-  FORMLY_VALIDATORS
-    .filter(opt => (field.templateOptions && field.templateOptions.hasOwnProperty(opt))
-      || (field.expressionProperties && field.expressionProperties[`templateOptions.${opt}`]),
-    )
-    .forEach((opt) => {
-      validators.push((control: FormControl) => {
-        if (field.templateOptions[opt] === false) {
-          return null;
-        }
-
-        return getValidation(opt, field.templateOptions[opt])(control);
-      });
-    });
-
-  if (field.validators) {
-    for (let validatorName in field.validators) {
-      if (validatorName !== 'validation') {
-        validators.push((control: FormControl) => {
-          let validator = field.validators[validatorName];
-          if (isObject(validator)) {
-            validator = validator.expression;
-          }
-
-          return validator(control, field) ? null : {[validatorName]: true};
-        });
-      }
-    }
-  }
-
-  if (field.validators && Array.isArray(field.validators.validation)) {
-    field.validators.validation.forEach((validate: any) => {
-      if (typeof validate === 'string') {
-        validators.push(this.formlyConfig.getValidator(validate).validation);
-      } else {
-        validators.push(validate);
-      }
-    });
-  }
-
-  if (validators.length) {
-    if (field.validators && !Array.isArray(field.validators.validation)) {
-      field.validators.validation = Validators.compose([field.validators.validation, ...validators]);
-    } else {
-      field.validators = {
-        validation: Validators.compose(validators),
-      };
-    }
-  }
-}
-
-function getValidation(opt: string, value: any) {
-  switch (opt) {
-    case 'required':
-      return Validators.required;
-    case 'pattern':
-      return Validators.pattern(value);
-    case 'minLength':
-      return Validators.minLength(value);
-    case 'maxLength':
-      return Validators.maxLength(value);
-    case 'min':
-      return Validators.min(value);
-    case 'max':
-      return Validators.max(value);
-  }
-}
-
-function addFormControl(form: FormGroup | FormArray, field: FormlyFieldConfig, model: any, path: string) {
-  const control = new FormControl(
-    model[path],
-    field.validators ? field.validators.validation : undefined,
-  );
-
-  addControl(form, path, control, field);
-}
-
-function addControl(form: FormGroup | FormArray, key: string | number, formControl: AbstractControl, field?: FormlyFieldConfig) {
-  if (field) {
-    field.formControl = formControl;
-  }
-
-  if (form instanceof FormArray) {
-    if (form.at(<number> key) !== formControl) {
-      form.setControl(<number>key, formControl);
-    }
-  } else {
-    if (form.get(<string> key) !== formControl) {
-      form.setControl(<string>key, formControl);
-    }
-  }
-}
-
-// TODO
 describe('FormlyFormExpression service', () => {
   let expression: FormlyFormExpression;
   let form: FormGroup;
+  let builder: FormlyFormBuilder;
+  let TestComponent: Component;
 
   beforeEach(() => {
+    TestComponent = MockComponent({ selector: 'formly-test-cmp' });
     expression = new FormlyFormExpression();
     form = new FormGroup({});
+    builder = new FormlyFormBuilder(
+      new FormlyConfig([{
+        types: [{ name: 'input', component: TestComponent }, { name: 'checkbox', component: TestComponent }],
+        wrappers: [{ name: 'label', component: TestComponent, types: ['input'] }],
+        validators: [{ name: 'required', validation: Validators.required }],
+      }]),
+      new FormlyFormExpression(),
+    );
   });
 
   it('should update field visibility', () => {
@@ -192,7 +43,7 @@ describe('FormlyFormExpression service', () => {
     const model = {};
     const options = {};
 
-    registerFormControls(form, fields, model, options);
+    builder.buildForm(form, fields, model, options);
 
     expression.checkFields(form, fields, model, options);
 
@@ -224,7 +75,7 @@ describe('FormlyFormExpression service', () => {
     const model = {};
     const options = {};
 
-    registerFormControls(form, fields, model, options);
+    builder.buildForm(form, fields, model, options);
 
     // manually disable the form control so that service can enable on `checkFields`
     fields[1].formControl.disable();
@@ -266,7 +117,7 @@ describe('FormlyFormExpression service', () => {
     };
     const options = {};
 
-    registerFormControls(form, fields, model, options);
+    builder.buildForm(form, fields, model, options);
 
     expression.checkFields(form, fields, model, options);
 

--- a/src/core/src/services/formly.form.expression.spec.ts
+++ b/src/core/src/services/formly.form.expression.spec.ts
@@ -1,15 +1,281 @@
 import { FormlyConfig } from './formly.config';
-import { Validators, FormGroup } from '@angular/forms';
+import { FormlyFieldConfig, FormlyFormOptions } from '../core';
+import { AbstractControl, FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Component } from '@angular/core';
+import { evalStringExpression, evalExpressionValueSetter, FORMLY_VALIDATORS, getKeyPath, isFunction, isObject } from './../utils';
 
 import { FormlyFormExpression } from './formly.form.expression';
+
+function registerFormControls(form: FormGroup | FormArray, fields: FormlyFieldConfig[], model: any, options: FormlyFormOptions) {
+  fields.forEach((field, index) => {
+    initFieldOptions(field);
+    initFieldExpression(field, model, options);
+    initFieldValidation(field);
+
+    if (field.key && field.type) {
+      const paths = getKeyPath({ key: field.key });
+      let rootForm = form, rootModel = model;
+      paths.forEach((path, index) => {
+        // FormGroup/FormArray only allow string value for path
+        const formPath = path.toString();
+        // is last item
+        if (index === paths.length - 1) {
+          addFormControl(rootForm, field, rootModel, formPath);
+        } else {
+          let nestedForm = rootForm.get(formPath) as FormGroup;
+          if (!nestedForm) {
+            nestedForm = new FormGroup({});
+            addControl(rootForm, formPath, nestedForm);
+          }
+          if (!rootModel[path]) {
+            rootModel[path] = typeof path === 'string' ? {} : [];
+          }
+
+          rootForm = nestedForm;
+          rootModel = rootModel[path];
+        }
+      });
+    }
+  });
+}
+
+function initFieldOptions(field: FormlyFieldConfig) {
+  field.templateOptions = field.templateOptions || {};
+  if (field.type) {
+    if (field.key) {
+      field.templateOptions = Object.assign({
+        label: '',
+        placeholder: '',
+        focus: false,
+      }, field.templateOptions);
+    }
+  }
+}
+
+function initFieldExpression(field: FormlyFieldConfig, model: any, options: FormlyFormOptions) {
+  if (field.expressionProperties) {
+    for (let key in field.expressionProperties as any) {
+      if (typeof field.expressionProperties[key] === 'string' || isFunction(field.expressionProperties[key])) {
+        // cache built expression
+        field.expressionProperties[key] = {
+          expression: isFunction(field.expressionProperties[key]) ? field.expressionProperties[key] : evalStringExpression(field.expressionProperties[key], ['model', 'formState']),
+          expressionValueSetter: evalExpressionValueSetter(key, ['expressionValue', 'model', 'templateOptions', 'validation', 'field']),
+        };
+      }
+    }
+  }
+
+  if (field.hideExpression) {
+    if (typeof field.hideExpression === 'string') {
+      // cache built expression
+      field.hideExpression = evalStringExpression(field.hideExpression, ['model', 'formState']);
+    }
+  }
+}
+
+function initFieldValidation(field: FormlyFieldConfig) {
+  let validators: any = [];
+  FORMLY_VALIDATORS
+    .filter(opt => (field.templateOptions && field.templateOptions.hasOwnProperty(opt))
+      || (field.expressionProperties && field.expressionProperties[`templateOptions.${opt}`]),
+    )
+    .forEach((opt) => {
+      validators.push((control: FormControl) => {
+        if (field.templateOptions[opt] === false) {
+          return null;
+        }
+
+        return getValidation(opt, field.templateOptions[opt])(control);
+      });
+    });
+
+  if (field.validators) {
+    for (let validatorName in field.validators) {
+      if (validatorName !== 'validation') {
+        validators.push((control: FormControl) => {
+          let validator = field.validators[validatorName];
+          if (isObject(validator)) {
+            validator = validator.expression;
+          }
+
+          return validator(control, field) ? null : {[validatorName]: true};
+        });
+      }
+    }
+  }
+
+  if (field.validators && Array.isArray(field.validators.validation)) {
+    field.validators.validation.forEach((validate: any) => {
+      if (typeof validate === 'string') {
+        validators.push(this.formlyConfig.getValidator(validate).validation);
+      } else {
+        validators.push(validate);
+      }
+    });
+  }
+
+  if (validators.length) {
+    if (field.validators && !Array.isArray(field.validators.validation)) {
+      field.validators.validation = Validators.compose([field.validators.validation, ...validators]);
+    } else {
+      field.validators = {
+        validation: Validators.compose(validators),
+      };
+    }
+  }
+}
+
+function getValidation(opt: string, value: any) {
+  switch (opt) {
+    case 'required':
+      return Validators.required;
+    case 'pattern':
+      return Validators.pattern(value);
+    case 'minLength':
+      return Validators.minLength(value);
+    case 'maxLength':
+      return Validators.maxLength(value);
+    case 'min':
+      return Validators.min(value);
+    case 'max':
+      return Validators.max(value);
+  }
+}
+
+function addFormControl(form: FormGroup | FormArray, field: FormlyFieldConfig, model: any, path: string) {
+  const control = new FormControl(
+    model[path],
+    field.validators ? field.validators.validation : undefined,
+  );
+
+  addControl(form, path, control, field);
+}
+
+function addControl(form: FormGroup | FormArray, key: string | number, formControl: AbstractControl, field?: FormlyFieldConfig) {
+  if (field) {
+    field.formControl = formControl;
+  }
+
+  if (form instanceof FormArray) {
+    if (form.at(<number> key) !== formControl) {
+      form.setControl(<number>key, formControl);
+    }
+  } else {
+    if (form.get(<string> key) !== formControl) {
+      form.setControl(<string>key, formControl);
+    }
+  }
+}
 
 // TODO
 describe('FormlyFormExpression service', () => {
   let expression: FormlyFormExpression;
+  let form: FormGroup;
 
   beforeEach(() => {
     expression = new FormlyFormExpression();
+    form = new FormGroup({});
   });
 
+  it('should update field visibility', () => {
+    const fields: FormlyFieldConfig[] = [
+      {
+        key: 'visibilityToggle',
+        type: 'input',
+      },
+      {
+        key: 'text',
+        type: 'input',
+        hideExpression: '!model.visibilityToggle',
+      },
+    ];
+    const model = {};
+    const options = {};
+
+    registerFormControls(form, fields, model, options);
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[1].hide).toBeTruthy();
+    expect(fields[1].templateOptions.hidden).toBeTruthy();
+
+    model['visibilityToggle'] = 'test';
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[1].hide).toBeFalsy();
+    expect(fields[1].templateOptions.hidden).toBeFalsy();
+  });
+
+  it('should update field disabled state', () => {
+    const fields: FormlyFieldConfig[] = [
+      {
+        key: 'disableToggle',
+        type: 'checkbox',
+      },
+      {
+        key: 'text',
+        type: 'input',
+        expressionProperties: {
+          'templateOptions.disabled': 'model.disableToggle',
+        },
+      },
+    ];
+    const model = {};
+    const options = {};
+
+    registerFormControls(form, fields, model, options);
+
+    // manually disable the form control so that service can enable on `checkFields`
+    fields[1].formControl.disable();
+
+    expect(fields[1].formControl.status).toEqual('DISABLED');
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[1].formControl.status).toEqual('VALID');
+    expect(fields[1].templateOptions.disabled).toBeFalsy();
+
+    model['disableToggle'] = true;
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[1].formControl.status).toEqual('DISABLED');
+    expect(fields[1].templateOptions.disabled).toBeTruthy();
+  });
+
+  it('should update the fields validity', () => {
+    const fields: FormlyFieldConfig[] = [
+      {
+        key: 'checked',
+        type: 'checkbox',
+      },
+      {
+        key: 'text',
+        type: 'input',
+        templateOptions: {
+          label: 'Am I required or not?',
+        },
+        expressionProperties: {
+          'templateOptions.required': 'model.checked',
+        },
+      },
+    ];
+    const model = {
+      checked: true,
+    };
+    const options = {};
+
+    registerFormControls(form, fields, model, options);
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[1].formControl.status).toEqual('INVALID');
+
+    model.checked = false;
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[1].formControl.status).toEqual('VALID');
+  });
 });

--- a/src/core/src/services/formly.form.expression.spec.ts
+++ b/src/core/src/services/formly.form.expression.spec.ts
@@ -129,4 +129,46 @@ describe('FormlyFormExpression service', () => {
 
     expect(fields[1].formControl.status).toEqual('VALID');
   });
+
+  it('should support field expression changes within field groups', () => {
+    const fields: FormlyFieldConfig[] = [
+      {
+        key: 'fieldgroup',
+        fieldGroup: [
+          {
+            key: 'checked',
+            type: 'checkbox',
+          },
+          {
+            key: 'text',
+            type: 'input',
+            templateOptions: {
+              label: 'Am I required or not?',
+            },
+            expressionProperties: {
+              'templateOptions.required': 'model.checked',
+            },
+          },
+        ],
+      },
+    ];
+    const model = {
+      fieldgroup: {
+        checked: true,
+      },
+    };
+    const options = {};
+
+    builder.buildForm(form, fields, model, options);
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[0].fieldGroup[1].formControl.status).toEqual('INVALID');
+
+    model.fieldgroup.checked = false;
+
+    expression.checkFields(form, fields, model, options);
+
+    expect(fields[0].fieldGroup[1].formControl.status).toEqual('VALID');
+  });
 });

--- a/src/core/src/test-utils.ts
+++ b/src/core/src/test-utils.ts
@@ -1,4 +1,5 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Component, EventEmitter } from '@angular/core';
 
 export function createGenericTestComponent<T>(html: string, type: {new (...args: any[]): T}): ComponentFixture<T> {
   TestBed.overrideComponent(type, {set: {template: html}});
@@ -6,3 +7,23 @@ export function createGenericTestComponent<T>(html: string, type: {new (...args:
   fixture.detectChanges();
   return fixture as ComponentFixture<T>;
 }
+
+// Source copied from https://github.com/cnunciato/ng2-mock-component
+export function MockComponent(options: Component): Component {
+  const metadata: Component = {
+    selector: options.selector,
+    template: options.template || '',
+    inputs: options.inputs,
+    outputs: options.outputs || [],
+    exportAs: options.exportAs || '',
+  };
+
+  class Mock {}
+
+  metadata.outputs.forEach(method => {
+    Mock.prototype[method] = new EventEmitter<any>();
+  });
+
+  return Component(metadata)(Mock as any);
+}
+

--- a/src/ui-material/src/types/select.spec.ts
+++ b/src/ui-material/src/types/select.spec.ts
@@ -68,7 +68,7 @@ describe('ui-material: Formly Field Select Component', () => {
       expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
     });
 
-    xit('should correctly bind to an Observable', async(() => {
+    it('should correctly bind to an Observable', async(() => {
       const sports$ = of([
         { id: '1', name: 'Soccer' },
         { id: '2', name: 'Basketball' },


### PR DESCRIPTION
Add unit tests for newly abstracted service.
See https://github.com/formly-js/ngx-formly/issues/711

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Tests

**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

I'm fairly new to this library so I didn't create any stubs instead I copied over several setup functions from Form Builder. I tried to keep it at a minimum but I don't think it's very sustainable, so this PR is open for discussion :) Also, I haven't tested more complicated `FormGroup` scenarios like nested or `FormArray`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/842)
<!-- Reviewable:end -->
