### PR TITLE
Added ng-content to formly-group. Updated Examples to inline remove btn

### DIFF
--- a/demo/src/app/examples/advanced/repeating-section/app.component.ts
+++ b/demo/src/app/examples/advanced/repeating-section/app.component.ts
@@ -35,7 +35,7 @@ export class AppComponent {
           {
             type: 'input',
             key: 'investmentDate',
-            className: 'col-sm-4',
+            className: 'col-sm-3',
             templateOptions: {
               type: 'date',
               label: 'Date of Investment:',
@@ -44,7 +44,7 @@ export class AppComponent {
           {
             type: 'input',
             key: 'stockIdentifier',
-            className: 'col-sm-4',
+            className: 'col-sm-3',
             templateOptions: {
               label: 'Stock Identifier:',
               addonRight: {

--- a/demo/src/app/examples/advanced/repeating-section/repeat-section.type.ts
+++ b/demo/src/app/examples/advanced/repeating-section/repeat-section.type.ts
@@ -10,10 +10,10 @@ import { FieldArrayType, FormlyFormBuilder } from '@ngx-formly/core';
         [field]="field"
         [options]="options"
         [form]="formControl">
+        <div class="col-sm-2 d-flex align-items-center">
+          <button class="btn btn-danger" type="button" (click)="remove(i)">Remove</button>
+        </div>
       </formly-group>
-      <div class="col-md-2">
-        <button class="btn btn-danger" type="button" (click)="remove(i)">Remove</button>
-      </div>
     </div>
     <div style="margin:30px 0;">
       <button class="btn btn-primary" type="button" (click)="add()">Add More Investments</button>

--- a/src/core/src/components/formly.group.ts
+++ b/src/core/src/components/formly.group.ts
@@ -11,6 +11,7 @@ import { FieldType } from '../templates/field.type';
       [form]="field.formControl || form"
       [options]="options"
       [ngClass]="field.fieldGroupClassName">
+      <ng-content></ng-content>
     </formly-form>
   `,
 })


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Added ng-content to formly-group. So that users can add content inside the field group such as Remove button.


**What is the current behavior? (You can also link to an open issue here)**
#840 


**What is the new behavior (if this is a feature change)?**
Users able to add html content inside field group


**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/843)
<!-- Reviewable:end -->
