### PR TITLE
fix(core): skip managing FormGroup status when it has children.

### DIFF
--- a/src/core/src/components/formly.form.spec.ts
+++ b/src/core/src/components/formly.form.spec.ts
@@ -460,7 +460,7 @@ describe('Formly Form Component', () => {
       expect(form.get('title').enabled).toEqual(false);
     });
 
-    it('should enable/disable formControl when templateOptions.disabled and fieldGroup are set', () => {
+    it('should enable parent formControl when child is enabled', () => {
       delete field.type;
       field.key = 'address';
       field.expressionProperties = {
@@ -480,8 +480,8 @@ describe('Formly Form Component', () => {
       ];
 
       const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>');
-      expect(field.templateOptions.disabled).toEqual(true);
-      expect(field.fieldGroup[0].templateOptions.disabled).toEqual(true);
+      expect(field.templateOptions.disabled).toEqual(false);
+      expect(field.fieldGroup[0].templateOptions.disabled).toEqual(false);
     });
 
     const options = [

--- a/src/core/src/services/formly.form.builder.spec.ts
+++ b/src/core/src/services/formly.form.builder.spec.ts
@@ -70,7 +70,7 @@ describe('FormlyFormBuilder service', () => {
       field = { key: 'title', type: 'input', templateOptions: { placeholder: 'Title' } };
       builder.buildForm(form, [field], {}, {});
 
-      expect(field.templateOptions).toEqual(<any> { label: '', placeholder: 'Title', focus: false });
+      expect(field.templateOptions).toEqual(<any> { label: '', placeholder: 'Title', focus: false, disabled: false });
     });
 
     it('should set the default value if the specified key and type is defined for fieldGroup', () => {
@@ -80,7 +80,7 @@ describe('FormlyFormBuilder service', () => {
       };
       builder.buildForm(form, [field], {}, {});
       expect(field.type).toEqual('formly-group');
-      expect(field.fieldGroup[0].templateOptions).toEqual(<any> { label: '', placeholder: 'Title', focus: false });
+      expect(field.fieldGroup[0].templateOptions).toEqual(<any> { label: '', placeholder: 'Title', focus: false, disabled: false });
     });
   });
 

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -271,6 +271,23 @@ export class FormlyFormBuilder {
       control.disable();
     }
 
+    // Replace decorated property with a getter that returns the observable.
+    // https://github.com/angular-redux/store/blob/master/src/decorators/select.ts#L79-L85
+    if (delete field.templateOptions.disabled) {
+      Object.defineProperty(field.templateOptions, 'disabled', {
+        get: (function () { return !this.formControl.enabled; }).bind(field),
+        set: (function (value: boolean) {
+          if (this.expressionProperties && this.expressionProperties.hasOwnProperty('templateOptions.disabled')) {
+            this.expressionProperties['templateOptions.disabled'].expressionValue = value;
+          }
+
+          value ? this.formControl.disable() : this.formControl.enable();
+        }).bind(field),
+        enumerable: true,
+        configurable: true,
+      });
+    }
+
     this.addControl(form, path, control, field);
   }
 

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -125,18 +125,6 @@ export class FormlyFormBuilder {
         field.hideExpression = evalStringExpression(field.hideExpression, ['model', 'formState']);
       }
     }
-
-    if (field.key && field.fieldGroup && field.fieldGroup.length > 0 && field.expressionProperties && field.expressionProperties.hasOwnProperty('templateOptions.disabled')) {
-      field.fieldGroup.forEach(f => {
-        f.expressionProperties = f.expressionProperties || {};
-        let disabledExpression: any = f.expressionProperties['templateOptions.disabled'] || (() => false);
-        if (typeof disabledExpression === 'string') {
-          disabledExpression = evalStringExpression(disabledExpression, ['model', 'formState']);
-        }
-
-        f.expressionProperties['templateOptions.disabled'] = (model: any, formState: any) => field.templateOptions.disabled || disabledExpression(model, formState);
-      });
-    }
   }
 
   private initFieldOptions(field: FormlyFieldConfig) {

--- a/src/core/src/services/formly.form.expression.spec.ts
+++ b/src/core/src/services/formly.form.expression.spec.ts
@@ -87,7 +87,7 @@ describe('FormlyFormExpression service', () => {
     builder.buildForm(form, fields, model, options);
 
     // manually disable the form control so that service can enable on `checkFields`
-    fields[1].formControl.disable();
+    fields[1].templateOptions.disabled = true;
 
     expect(fields[1].formControl.status).toEqual('DISABLED');
 

--- a/src/core/src/services/formly.form.expression.ts
+++ b/src/core/src/services/formly.form.expression.ts
@@ -63,18 +63,6 @@ export class FormlyFormExpression {
         }
       }
     }
-
-    if (field.expressionProperties.hasOwnProperty('templateOptions.disabled')) {
-      const formControl = field.formControl;
-      if (formControl) {
-        if (!formControl.enabled && !field.templateOptions.disabled) {
-          formControl.enable();
-        }
-        if (formControl.enabled && field.templateOptions.disabled) {
-          formControl.disable();
-        }
-      }
-    }
   }
 
   private checkFieldVisibilityChange(form: FormGroup | FormArray, field: FormlyFieldConfig, model: any, options: FormlyFormOptions) {


### PR DESCRIPTION
fix #844, fix #851

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/850)
<!-- Reviewable:end -->
