### PR TITLE
feat(core): remove `formControl` input in FormlyAttributes.

### DIFF
--- a/src/core/src/components/formly.attributes.spec.ts
+++ b/src/core/src/components/formly.attributes.spec.ts
@@ -6,6 +6,7 @@ import { Component } from '@angular/core';
 import { FormlyModule } from '../core';
 import { FormlyAttributes } from './formly.attributes';
 import { FormlyFieldConfig } from './formly.field.config';
+import { ReactiveFormsModule } from '@angular/forms';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -19,6 +20,7 @@ describe('FormlyAttributes Component', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [
+        ReactiveFormsModule,
         FormlyModule.forRoot(),
       ],
     });

--- a/src/core/src/components/formly.attributes.ts
+++ b/src/core/src/components/formly.attributes.ts
@@ -1,5 +1,4 @@
 import { Directive, HostListener, ElementRef, Input, OnChanges, SimpleChanges, SimpleChange, Renderer2 } from '@angular/core';
-import { AbstractControl } from '@angular/forms';
 import { FormlyFieldConfig } from './formly.field.config';
 
 @Directive({
@@ -7,7 +6,6 @@ import { FormlyFieldConfig } from './formly.field.config';
 })
 export class FormlyAttributes implements OnChanges {
   @Input('formlyAttributes') field: FormlyFieldConfig;
-  @Input() formControl: AbstractControl;
   private attributes = ['id', 'name', 'placeholder', 'tabindex', 'step', 'readonly'];
   private statements = ['change', 'keydown', 'keyup', 'keypress', 'click', 'focus', 'blur'];
 
@@ -67,7 +65,7 @@ export class FormlyAttributes implements OnChanges {
       console.warn(`FormlyForm: field(${this.field.key}) Passing formControl as a second argument for "${statement}" is deprecated and it will be removed in the 3.0 version, use "field.formControl" instead`);
     }
 
-    return (event: any) => fn.length !== 2 ? fn(this.field, event) : fn(this.field, this.formControl);
+    return (event: any) => fn.length !== 2 ? fn(this.field, event) : fn(this.field, this.field.formControl);
   }
 
   private canApplyRender(fieldChange: SimpleChange, prop: string): Boolean {

--- a/src/core/src/components/formly.field.spec.ts
+++ b/src/core/src/components/formly.field.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync, tick, TestBed, ComponentFixture } from '@angular/core/testin
 import { createGenericTestComponent } from '../test-utils';
 
 import { Component, ViewChild, ViewContainerRef } from '@angular/core';
-import { FormGroup, FormControl } from '@angular/forms';
+import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 import {
   FormlyModule,
   FieldType,
@@ -31,6 +31,7 @@ describe('FormlyField Component', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, FormlyFieldText, FormlyWrapperLabel],
       imports: [
+        ReactiveFormsModule,
         FormlyModule.forRoot({
           types: [
             {
@@ -70,11 +71,12 @@ describe('FormlyField Component', () => {
       field: {
         key: 'title',
         type: 'text',
+        formControl: new FormControl(),
         templateOptions: {
           placeholder: 'Title',
         },
       },
-      form: new FormGroup({title: new FormControl()}),
+      form: new FormGroup({}),
     };
 
     const fixture = createTestComponent('<formly-field [form]="form" [field]="field"></formly-field>');
@@ -92,16 +94,18 @@ describe('FormlyField Component', () => {
           {
             key: 'title1',
             type: 'text',
+            formControl: new FormControl(),
             templateOptions: { placeholder: 'Title1' },
           },
           {
             key: 'title2',
             type: 'text',
+            formControl: new FormControl(),
             templateOptions: { placeholder: 'Title2' },
           },
         ],
       },
-      form: new FormGroup({ title1: new FormControl(), title2: new FormControl() }),
+      form: new FormGroup({}),
     };
 
     const fixture = createTestComponent('<formly-field [form]="form" [field]="field"></formly-field>');
@@ -123,6 +127,7 @@ describe('FormlyField Component', () => {
         },
         form: new FormGroup({ title: new FormControl() }),
       };
+      testComponentInputs.field.formControl = testComponentInputs.form.get('title');
     });
 
     it('should render field without wrapper or key', () => {
@@ -176,12 +181,13 @@ describe('FormlyField Component', () => {
       field: {
         key: 'title',
         type: 'text',
+        formControl: new FormControl(),
         optionsTypes: ['other'],
         templateOptions: {
           placeholder: 'Title',
         },
       },
-      form: new FormGroup({title: new FormControl()}),
+      form: new FormGroup({}),
     };
 
     const fixture = createTestComponent('<formly-field [form]="form" [field]="field"></formly-field>');

--- a/src/core/src/components/formly.form.spec.ts
+++ b/src/core/src/components/formly.form.spec.ts
@@ -4,7 +4,7 @@ import { FormlyWrapperLabel, FormlyFieldText } from './formly.field.spec';
 
 import { Component, ViewChild } from '@angular/core';
 import { FormlyModule, FormlyFormBuilder } from '../core';
-import { FormGroup, FormArray, FormControl } from '@angular/forms';
+import { FormGroup, FormArray, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FieldArrayType } from '../templates/field-array.type';
 import { FormlyFormOptions } from './formly.field.config';
 import { FormlyForm } from './formly.form';
@@ -20,27 +20,32 @@ let testComponentInputs;
 
 describe('Formly Form Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldText, FormlyWrapperLabel, RepeatComponent], imports: [FormlyModule.forRoot({
-      types: [
-        {
-          name: 'text',
-          component: FormlyFieldText,
-        },
-        {
-          name: 'other',
-          component: FormlyFieldText,
-          wrappers: ['label'],
-        },
-        {
-          name: 'repeat',
-          component: RepeatComponent,
-        },
-      ],
-      wrappers: [{
-        name: 'label',
-        component: FormlyWrapperLabel,
-      }],
-    })]});
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, FormlyFieldText, FormlyWrapperLabel, RepeatComponent],
+      imports: [
+        ReactiveFormsModule,
+        FormlyModule.forRoot({
+          types: [
+            {
+              name: 'text',
+              component: FormlyFieldText,
+            },
+            {
+              name: 'other',
+              component: FormlyFieldText,
+              wrappers: ['label'],
+            },
+            {
+              name: 'repeat',
+              component: RepeatComponent,
+            },
+          ],
+          wrappers: [{
+            name: 'label',
+            component: FormlyWrapperLabel,
+          }],
+        }),
+      ]});
   });
 
   describe('modelChange output', () => {

--- a/src/core/src/templates/field.ts
+++ b/src/core/src/templates/field.ts
@@ -10,7 +10,7 @@ export abstract class Field {
 
   get key() { return this.field.key; }
 
-  get formControl(): AbstractControl { return this.field.formControl || this.form.get(this.key); }
+  get formControl(): AbstractControl { return this.field.formControl; }
 
   get to(): FormlyTemplateOptions { return this.field.templateOptions; }
 

--- a/src/core/src/templates/formly.validation-message.spec.ts
+++ b/src/core/src/templates/formly.validation-message.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test-utils';
 
 import { Component } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule, FormlyFieldConfig } from '@ngx-formly/core';
 
 const createTestComponent = (html: string) =>
@@ -17,6 +17,7 @@ describe('FormlyValidationMessage Component', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [
+        ReactiveFormsModule,
         FormlyModule.forRoot({
           validationMessages: [
             { name: 'required', message: (err, field) => `${field.templateOptions.label} is required.`},

--- a/src/ui-bootstrap/src/types/select.spec.ts
+++ b/src/ui-bootstrap/src/types/select.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 
 import { Component, ViewChild } from '@angular/core';
 import { FormlyModule } from '../../../core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormlyFieldSelect } from './select';
 import { FormlyForm } from '../../../core';
 import { of as observableOf } from 'rxjs/observable/of';
@@ -16,14 +16,17 @@ let testComponentInputs;
 
 describe('ui-bootstrap: Formly Field Select Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [FormlyModule.forRoot({
-      types: [
-        {
-          name: 'select',
-          component: FormlyFieldSelect,
-        },
-      ],
-    })]});
+    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [
+      ReactiveFormsModule,
+      FormlyModule.forRoot({
+        types: [
+          {
+            name: 'select',
+            component: FormlyFieldSelect,
+          },
+        ],
+      }),
+    ]});
   });
 
   describe('options', () => {

--- a/src/ui-material/src/types/select.spec.ts
+++ b/src/ui-material/src/types/select.spec.ts
@@ -6,7 +6,7 @@ import { By } from '@angular/platform-browser';
 
 import { Component, ViewChild } from '@angular/core';
 import { FormlyModule } from '../../../core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormlyFieldSelect } from './select';
 import { FormlyForm } from '../../../core';
 import { of as observableOf } from 'rxjs/observable/of';
@@ -23,6 +23,7 @@ describe('ui-material: Formly Field Select Component', () => {
       imports: [
         NoopAnimationsModule,
         MatSelectModule,
+        ReactiveFormsModule,
         FormlyModule.forRoot({
           types: [
             {


### PR DESCRIPTION
fix #642

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/862)
<!-- Reviewable:end -->
