### PR TITLE
feat(code): allow using key expression property without passing `field` path.

### DIFF
--- a/src/core/src/components/formly.form.spec.ts
+++ b/src/core/src/components/formly.form.spec.ts
@@ -384,7 +384,7 @@ describe('Formly Form Component', () => {
 
     it('should update className', () => {
       field.expressionProperties = {
-        'field.className': 'model.title',
+        'className': 'model.title',
       };
 
       const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>');

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -107,11 +107,20 @@ export class FormlyFormBuilder {
   private initFieldExpression(field: FormlyFieldConfig, model: any, options: FormlyFormOptions) {
     if (field.expressionProperties) {
       for (const key in field.expressionProperties as any) {
+        if (key.indexOf('field.') === 0) {
+          console.warn(`FormlyForm: field(${field.key}) using "field." path in "expressionProperties" is deprecated, use "${key.replace('field.', '')}" instead.`);
+        }
+
         if (typeof field.expressionProperties[key] === 'string' || isFunction(field.expressionProperties[key])) {
           // cache built expression
           field.expressionProperties[key] = {
             expression: isFunction(field.expressionProperties[key]) ? field.expressionProperties[key] : evalStringExpression(field.expressionProperties[key], ['model', 'formState']),
-            expressionValueSetter: evalExpressionValueSetter(key, ['expressionValue', 'model', 'templateOptions', 'validation', 'field']),
+            expressionValueSetter: evalExpressionValueSetter(
+              key.indexOf('field.') === 0 || key.indexOf('model.') === 0
+                ? key
+                : `field.${key}`,
+              ['expressionValue', 'model', 'field'],
+            ),
           };
         }
       }

--- a/src/core/src/services/formly.form.expression.ts
+++ b/src/core/src/services/formly.form.expression.ts
@@ -46,15 +46,19 @@ export class FormlyFormExpression {
         evalExpression(
           expressionProperties[key].expressionValueSetter,
           { field },
-          [expressionValue, model, field.templateOptions, field.validation, field],
+          [expressionValue, model, field],
         );
 
         if (key.indexOf('model.') === 0) {
           const path = key.replace(/^model\./, ''),
-            formControl = field.key && key === path ? field.formControl : form.get(path);
+            control = field.key && key === path ? field.formControl : form.get(path);
 
-          if (formControl) {
-            formControl.patchValue(expressionValue);
+          if (
+            control
+            && !(isNullOrUndefined(control.value) && isNullOrUndefined(expressionValue))
+            && control.value !== expressionValue
+          ) {
+            control.patchValue(expressionValue);
           }
         }
 
@@ -99,9 +103,13 @@ export class FormlyFormExpression {
   }
 
   private addFieldControl(parent: FormArray | FormGroup, field: FormlyFieldConfig, model: any) {
-    model = this.getFieldModel(model, field);
-    if (field.formControl.value !== model) {
-      field.formControl.patchValue(model, { emitEvent: false });
+    const fieldModel = this.getFieldModel(model, field);
+
+    if (
+      !(isNullOrUndefined(field.formControl.value) && isNullOrUndefined(fieldModel))
+      && field.formControl.value !== fieldModel
+    ) {
+      field.formControl.patchValue(fieldModel, { emitEvent: false });
     }
 
     if (parent instanceof FormArray) {


### PR DESCRIPTION
```patch
field.expressionProperties = {
-  'field.className': ...
+  'className': ...
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/863)
<!-- Reviewable:end -->
