### PR TITLE
fix(core): use `Field` instead `FormlyFieldConfig` in showError

### DIFF
--- a/src/core/src/services/formly.config.ts
+++ b/src/core/src/services/formly.config.ts
@@ -232,6 +232,6 @@ export interface ConfigOption {
   manipulators?: ManipulatorOption[];
   extras?: {
     fieldTransform?: any,
-    showError?: (field: FormlyFieldConfig) => boolean;
+    showError?: (field: Field) => boolean;
   };
 }


### PR DESCRIPTION
fix #877

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/878)
<!-- Reviewable:end -->
