### PR TITLE
fix(bootstrap): apply border radius for input when using addons

### DIFF
--- a/src/ui-bootstrap/src/wrappers/addons.ts
+++ b/src/ui-bootstrap/src/wrappers/addons.ts
@@ -22,6 +22,16 @@ import { FieldWrapper } from '@ngx-formly/core';
       </div>
     </div>
   `,
+  styles: [`
+    :host ::ng-deep .input-group>:not(:first-child)> .form-control {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+    :host ::ng-deep .input-group>:not(:last-child)> .form-control {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  `],
 })
 export class FormlyWrapperAddons extends FieldWrapper {
   @ViewChild('fieldComponent', {read: ViewContainerRef}) fieldComponent: ViewContainerRef;


### PR DESCRIPTION
fix #656

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/882)
<!-- Reviewable:end -->
