### PR TITLE
fix(bootstrap,meterial) Allow Select Type, Value to be a object

### DIFF
--- a/src/ui-bootstrap/src/types/select.spec.ts
+++ b/src/ui-bootstrap/src/types/select.spec.ts
@@ -1,3 +1,5 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSelectModule } from '@angular/material/select';
 import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { createGenericTestComponent } from '../../../core/src/test-utils';
 import { By } from '@angular/platform-browser';
@@ -10,20 +12,27 @@ import { FormlyForm } from '../../../core';
 import { of } from 'rxjs/observable/of';
 
 const createTestComponent = (html: string) =>
-    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+  createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 let testComponentInputs;
 
-describe('ui-bootstrap: Formly Field Select Component', () => {
+describe('ui-material: Formly Field Select Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [FormlyModule.forRoot({
-      types: [
-        {
-          name: 'select',
-          component: FormlyFieldSelect,
-        },
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, FormlyFieldSelect],
+      imports: [
+        NoopAnimationsModule,
+        MatSelectModule,
+        FormlyModule.forRoot({
+          types: [
+            {
+              name: 'select',
+              component: FormlyFieldSelect,
+            },
+          ],
+        }),
       ],
-    })]});
+    });
   });
 
   describe('options', () => {
@@ -37,22 +46,26 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
 
 
     it('should correctly bind to a static array of data', () => {
-        testComponentInputs.fields = [{
-            key: 'sportId',
-            type: 'select',
-            templateOptions: {
-                options: [
-                    { id: '1', name: 'Soccer' },
-                    { id: '2', name: 'Basketball' },
-                ],
-                valueProp: 'id',
-                labelProp: 'name',
-            },
-        }];
+      testComponentInputs.fields = [{
+        key: 'sportId',
+        type: 'select',
+        templateOptions: {
+          options: [
+            { id: '1', name: 'Soccer' },
+            { id: '2', name: 'Basketball' },
+          ],
+          valueProp: 'id',
+          labelProp: 'name',
+        },
+      }];
 
-        const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
 
-        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(2);
+      trigger.click();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
     });
 
     it('should correctly bind to an Observable', async(() => {
@@ -62,25 +75,29 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
       ]);
 
       testComponentInputs.fields = [{
-          key: 'sportId',
-          type: 'select',
-          templateOptions: {
-              options: sports$,
-              valueProp: 'id',
-              labelProp: 'name',
-          },
+        key: 'sportId',
+        type: 'select',
+        templateOptions: {
+          options: sports$,
+          valueProp: 'id',
+          labelProp: 'name',
+        },
       }];
 
-      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
 
-      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(2);
+      trigger.click();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
     }));
 
   });
 
 });
 
-@Component({selector: 'formly-form-test', template: '', entryComponents: []})
+@Component({ selector: 'formly-form-test', template: '', entryComponents: [] })
 class TestComponent {
   @ViewChild(FormlyForm) formlyForm: FormlyForm;
 

--- a/src/ui-bootstrap/src/types/select.spec.ts
+++ b/src/ui-bootstrap/src/types/select.spec.ts
@@ -1,5 +1,3 @@
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatSelectModule } from '@angular/material/select';
 import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { createGenericTestComponent } from '../../../core/src/test-utils';
 import { By } from '@angular/platform-browser';
@@ -12,27 +10,20 @@ import { FormlyForm } from '../../../core';
 import { of } from 'rxjs/observable/of';
 
 const createTestComponent = (html: string) =>
-  createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 let testComponentInputs;
 
-describe('ui-material: Formly Field Select Component', () => {
+describe('ui-bootstrap: Formly Field Select Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [TestComponent, FormlyFieldSelect],
-      imports: [
-        NoopAnimationsModule,
-        MatSelectModule,
-        FormlyModule.forRoot({
-          types: [
-            {
-              name: 'select',
-              component: FormlyFieldSelect,
-            },
-          ],
-        }),
+    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [FormlyModule.forRoot({
+      types: [
+        {
+          name: 'select',
+          component: FormlyFieldSelect,
+        },
       ],
-    });
+    })]});
   });
 
   describe('options', () => {
@@ -46,58 +37,52 @@ describe('ui-material: Formly Field Select Component', () => {
 
 
     it('should correctly bind to a static array of data', () => {
-      testComponentInputs.fields = [{
-        key: 'sportId',
-        type: 'select',
-        templateOptions: {
-          options: [
-            { id: '1', name: 'Soccer' },
-            { id: '2', name: 'Basketball' },
-          ],
-          valueProp: 'id',
-          labelProp: 'name',
-        },
-      }];
+        testComponentInputs.fields = [{
+            key: 'sportId',
+            type: 'select',
+            templateOptions: {
+                options: [
+                    { id: '1', name: 'Soccer' },
+                    { id: '2', name: 'Basketball' },
+                    { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
+                ],
+                valueProp: 'id',
+                labelProp: 'name',
+            },
+        }];
 
-      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
 
-      trigger.click();
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
+        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
     });
 
     it('should correctly bind to an Observable', async(() => {
       const sports$ = of([
         { id: '1', name: 'Soccer' },
         { id: '2', name: 'Basketball' },
+        { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
       ]);
 
       testComponentInputs.fields = [{
-        key: 'sportId',
-        type: 'select',
-        templateOptions: {
-          options: sports$,
-          valueProp: 'id',
-          labelProp: 'name',
-        },
+          key: 'sportId',
+          type: 'select',
+          templateOptions: {
+              options: sports$,
+              valueProp: 'id',
+              labelProp: 'name',
+          },
       }];
 
-      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
 
-      trigger.click();
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
+      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
     }));
 
   });
 
 });
 
-@Component({ selector: 'formly-form-test', template: '', entryComponents: [] })
+@Component({selector: 'formly-form-test', template: '', entryComponents: []})
 class TestComponent {
   @ViewChild(FormlyForm) formlyForm: FormlyForm;
 

--- a/src/ui-bootstrap/src/types/select.ts
+++ b/src/ui-bootstrap/src/types/select.ts
@@ -5,12 +5,12 @@ import { of } from 'rxjs/observable/of';
 
 export class SelectOption {
   label: string;
-  value?: string;
+  value?: any;
   group?: SelectOption[];
   disabled?: boolean;
   [key: string]: any;
 
-  constructor(label: string, value?: string, children?: SelectOption[]) {
+  constructor(label: string, value?: any, children?: SelectOption[]) {
     this.label = label;
     this.value = value;
     this.group = children;

--- a/src/ui-material/src/types/select.spec.ts
+++ b/src/ui-material/src/types/select.spec.ts
@@ -1,3 +1,5 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSelectModule } from '@angular/material/select';
 import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { createGenericTestComponent } from '../../../core/src/test-utils';
 import { By } from '@angular/platform-browser';
@@ -10,20 +12,27 @@ import { FormlyForm } from '../../../core';
 import { of } from 'rxjs/observable/of';
 
 const createTestComponent = (html: string) =>
-    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+  createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 let testComponentInputs;
 
-describe('ui-bootstrap: Formly Field Select Component', () => {
+describe('ui-material: Formly Field Select Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [FormlyModule.forRoot({
-      types: [
-        {
-          name: 'select',
-          component: FormlyFieldSelect,
-        },
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, FormlyFieldSelect],
+      imports: [
+        NoopAnimationsModule,
+        MatSelectModule,
+        FormlyModule.forRoot({
+          types: [
+            {
+              name: 'select',
+              component: FormlyFieldSelect,
+            },
+          ],
+        }),
       ],
-    })]});
+    });
   });
 
   describe('options', () => {
@@ -37,23 +46,27 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
 
 
     it('should correctly bind to a static array of data', () => {
-        testComponentInputs.fields = [{
-            key: 'sportId',
-            type: 'select',
-            templateOptions: {
-                options: [
-                    { id: '1', name: 'Soccer' },
-                    { id: '2', name: 'Basketball' },
-                    { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
-                ],
-                valueProp: 'id',
-                labelProp: 'name',
-            },
-        }];
+      testComponentInputs.fields = [{
+        key: 'sportId',
+        type: 'select',
+        templateOptions: {
+          options: [
+            { id: '1', name: 'Soccer' },
+            { id: '2', name: 'Basketball' },
+            { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
+          ],
+          valueProp: 'id',
+          labelProp: 'name',
+        },
+      }];
 
-        const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
 
-        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
+      trigger.click();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(3);
     });
 
     it('should correctly bind to an Observable', async(() => {
@@ -64,25 +77,29 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
       ]);
 
       testComponentInputs.fields = [{
-          key: 'sportId',
-          type: 'select',
-          templateOptions: {
-              options: sports$,
-              valueProp: 'id',
-              labelProp: 'name',
-          },
+        key: 'sportId',
+        type: 'select',
+        templateOptions: {
+          options: sports$,
+          valueProp: 'id',
+          labelProp: 'name',
+        },
       }];
 
-      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
 
-      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
+      trigger.click();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(3);
     }));
 
   });
 
 });
 
-@Component({selector: 'formly-form-test', template: '', entryComponents: []})
+@Component({ selector: 'formly-form-test', template: '', entryComponents: [] })
 class TestComponent {
   @ViewChild(FormlyForm) formlyForm: FormlyForm;
 

--- a/src/ui-material/src/types/select.spec.ts
+++ b/src/ui-material/src/types/select.spec.ts
@@ -1,5 +1,3 @@
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatSelectModule } from '@angular/material/select';
 import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { createGenericTestComponent } from '../../../core/src/test-utils';
 import { By } from '@angular/platform-browser';
@@ -12,27 +10,20 @@ import { FormlyForm } from '../../../core';
 import { of } from 'rxjs/observable/of';
 
 const createTestComponent = (html: string) =>
-  createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 let testComponentInputs;
 
-describe('ui-material: Formly Field Select Component', () => {
+describe('ui-bootstrap: Formly Field Select Component', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [TestComponent, FormlyFieldSelect],
-      imports: [
-        NoopAnimationsModule,
-        MatSelectModule,
-        FormlyModule.forRoot({
-          types: [
-            {
-              name: 'select',
-              component: FormlyFieldSelect,
-            },
-          ],
-        }),
+    TestBed.configureTestingModule({declarations: [TestComponent, FormlyFieldSelect], imports: [FormlyModule.forRoot({
+      types: [
+        {
+          name: 'select',
+          component: FormlyFieldSelect,
+        },
       ],
-    });
+    })]});
   });
 
   describe('options', () => {
@@ -46,58 +37,52 @@ describe('ui-material: Formly Field Select Component', () => {
 
 
     it('should correctly bind to a static array of data', () => {
-      testComponentInputs.fields = [{
-        key: 'sportId',
-        type: 'select',
-        templateOptions: {
-          options: [
-            { id: '1', name: 'Soccer' },
-            { id: '2', name: 'Basketball' },
-          ],
-          valueProp: 'id',
-          labelProp: 'name',
-        },
-      }];
+        testComponentInputs.fields = [{
+            key: 'sportId',
+            type: 'select',
+            templateOptions: {
+                options: [
+                    { id: '1', name: 'Soccer' },
+                    { id: '2', name: 'Basketball' },
+                    { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
+                ],
+                valueProp: 'id',
+                labelProp: 'name',
+            },
+        }];
 
-      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
 
-      trigger.click();
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
+        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
     });
 
     it('should correctly bind to an Observable', async(() => {
       const sports$ = of([
         { id: '1', name: 'Soccer' },
         { id: '2', name: 'Basketball' },
+        { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
       ]);
 
       testComponentInputs.fields = [{
-        key: 'sportId',
-        type: 'select',
-        templateOptions: {
-          options: sports$,
-          valueProp: 'id',
-          labelProp: 'name',
-        },
+          key: 'sportId',
+          type: 'select',
+          templateOptions: {
+              options: sports$,
+              valueProp: 'id',
+              labelProp: 'name',
+          },
       }];
 
-      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>'),
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
 
-      trigger.click();
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
+      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
     }));
 
   });
 
 });
 
-@Component({ selector: 'formly-form-test', template: '', entryComponents: [] })
+@Component({selector: 'formly-form-test', template: '', entryComponents: []})
 class TestComponent {
   @ViewChild(FormlyForm) formlyForm: FormlyForm;
 

--- a/src/ui-material/src/types/select.ts
+++ b/src/ui-material/src/types/select.ts
@@ -6,12 +6,12 @@ import { Observable } from 'rxjs/Observable';
 
 export class SelectOption {
   label: string;
-  value?: string;
+  value?: any;
   group?: SelectOption[];
   disabled?: boolean;
   [key: string]: any;
 
-  constructor(label: string, value?: string, children?: SelectOption[]) {
+  constructor(label: string, value?: any, children?: SelectOption[]) {
     this.label = label;
     this.value = value;
     this.group = children;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix ->This allows select type, the actual value to be an object


**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

See example.
https://stackblitz.com/edit/ngx-formly-select-as-value?file=app/app.component.ts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/910)
<!-- Reviewable:end -->
