### PR TITLE
feat(core): move createControl FieldArrayType to core

### DIFF
--- a/src/core/src/services/formly.form.builder.spec.ts
+++ b/src/core/src/services/formly.form.builder.spec.ts
@@ -23,39 +23,41 @@ describe('FormlyFormBuilder service', () => {
     );
   });
 
-  it('should use the same formcontrol for fields that use the same key', () => {
-    const fields: FormlyFieldConfig[] = [
-      { key: 'test', type: 'input', hide: true },
-      { key: 'test', type: 'input' },
-    ];
+  describe('formcontrol', () => {
+    it('should use the same formcontrol for fields that use the same key', () => {
+      const fields: FormlyFieldConfig[] = [
+        { key: 'test', type: 'input', hide: true },
+        { key: 'test', type: 'input' },
+      ];
 
-    builder.buildForm(form, fields, {}, {});
-    expect(fields[0].formControl).toEqual(fields[1].formControl);
-  });
+      builder.buildForm(form, fields, {}, {});
+      expect(fields[0].formControl).toEqual(fields[1].formControl);
+    });
 
-  it('should update the formcontrol value for fields that already has formcontrol', () => {
-    const fields: FormlyFieldConfig[] = [
-      {
-        key: 'test',
-        type: 'input',
-        formControl: new FormControl(),
-      },
-      {
-        key: 'fieldGroup',
-        type: 'input',
-        formControl: new FormGroup({ aa: new FormControl('aa') }),
-      },
-      {
-        key: 'fieldArray',
-        type: 'input',
-        formControl: new FormArray([new FormControl('aa')]),
-      },
-    ];
+    it('should update the formcontrol value for fields that already has formcontrol', () => {
+      const fields: FormlyFieldConfig[] = [
+        {
+          key: 'test',
+          type: 'input',
+          formControl: new FormControl(),
+        },
+        {
+          key: 'fieldGroup',
+          type: 'input',
+          formControl: new FormGroup({ aa: new FormControl('aa') }),
+        },
+        {
+          key: 'fieldArray',
+          type: 'input',
+          formControl: new FormArray([new FormControl('aa')]),
+        },
+      ];
 
-    builder.buildForm(form, fields, { test: 'test' }, {});
-    expect(fields[0].formControl.value).toEqual('test');
-    expect(fields[1].formControl.value).toEqual({ aa: 'aa' });
-    expect(fields[2].formControl.value).toEqual(['aa']);
+      builder.buildForm(form, fields, { test: 'test' }, {});
+      expect(fields[0].formControl.value).toEqual('test');
+      expect(fields[1].formControl.value).toEqual({ aa: 'aa' });
+      expect(fields[2].formControl.value).toEqual(['aa']);
+    });
   });
 
   describe('initialise default TemplateOptions', () => {
@@ -439,6 +441,25 @@ describe('FormlyFormBuilder service', () => {
           expectValidators(option.invalid, option.valid);
         });
       });
+    });
+  });
+
+  describe('fieldArray', () => {
+    it('should create/build fieldGroup when model is set', () => {
+      const fields: FormlyFieldConfig[] = [
+        {
+          key: 'array',
+          type: 'input',
+          fieldArray: {
+            key: 'test',
+            type: 'input',
+          },
+        },
+      ];
+
+      builder.buildForm(form, fields, { array: ['aaa'] }, {});
+
+      expect(fields[0].fieldGroup.length).toEqual(1);
     });
   });
 });

--- a/src/core/src/templates/field-array.type.ts
+++ b/src/core/src/templates/field-array.type.ts
@@ -1,26 +1,10 @@
 import { FormArray } from '@angular/forms';
-import { FormlyFieldConfig } from '../components/formly.field.config';
 import { FieldType } from './field.type';
 import { clone, isNullOrUndefined } from '../utils';
 import { FormlyFormBuilder } from '../services/formly.form.builder';
 
 export abstract class FieldArrayType extends FieldType {
   formControl: FormArray;
-
-  static createControl(model: any, field: FormlyFieldConfig): FormArray {
-    const form = new FormArray(
-      [],
-      field.validators ? field.validators.validation : undefined,
-      field.asyncValidators ? field.asyncValidators.validation : undefined,
-    );
-
-    field.fieldGroup = [];
-    (model || []).forEach((m: any, i: number) => field.fieldGroup.push(
-      { ...clone(field.fieldArray), key: `${i}` },
-    ));
-
-    return form;
-  }
 
  constructor(private builder: FormlyFormBuilder) {
     super();


### PR DESCRIPTION
BREAKING CHANGE: createControl in FieldArrayType has been removed

fix #909

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ngx-formly/912)
<!-- Reviewable:end -->
