### PR TITLE
chore(schematics): fix schematics pkg version

### DIFF
--- a/.config/version-schematics.js
+++ b/.config/version-schematics.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+// Schematics is NOT an `ng-package` and therefore requires a valid semver version
+const packagePath = 'dist/@ngx-formly/schematics';
+
+package = fs.readFileSync(`${packagePath}/package.json`, 'utf8');
+fs.writeFileSync(`${packagePath}/package.json`, package.replace(/0\.0\.0/g, 'FORMLY-VERSION'));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:primeng": "ng build @ngx-formly/primeng",
     "build:kendo": "ng build @ngx-formly/kendo",
     "build:schematics": "cd src/schematics && npm run build && cd ../.. && npm run copy:schematics",
-    "copy:schematics": "cpr src/schematics dist/@ngx-formly/schematics --delete-first --filter node_modules/",
+    "copy:schematics": "cpr src/schematics dist/@ngx-formly/schematics --delete-first --filter node_modules/ && node .config/version-schematics.js",
     "release": "standard-version && npm run build && node .config/publish.js",
     "start": "ng serve --port 4100 --open",
     "demo": "npm run start",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Version fix for Schematics package.

**What is the current behavior? (You can also link to an open issue here)**

Schematics published version is `0.0.1`.
Schematics has a different build process from the other `ngx-formly` packages and therefore needs a slightly modified build process.

**What is the new behavior (if this is a feature change)?**

To not alter too much, add a step to overwrite the dist `package.json` to have the "FORMLY_VERSION" key that is used to update to correct Formly version on builds.

**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
