### PR TITLE
docs(demo): use btnText in repeating-section

### DIFF
--- a/demo/src/app/examples/advanced/repeating-section/repeat-section.type.ts
+++ b/demo/src/app/examples/advanced/repeating-section/repeat-section.type.ts
@@ -16,7 +16,7 @@ import { FieldArrayType, FormlyFormBuilder } from '@ngx-formly/core';
       </formly-group>
     </div>
     <div style="margin:30px 0;">
-      <button class="btn btn-primary" type="button" (click)="add()">Add More Investments</button>
+      <button class="btn btn-primary" type="button" (click)="add()">{{ field.fieldArray.templateOptions.btnText }}</button>
     </div>
   `,
 })


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update - Clears up some confusion regarding the button text in the [repeating-section example](https://formly-js.github.io/ngx-formly/examples/advanced/repeating-section).

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Other information**:
Fix submitted due to https://github.com/formly-js/ngx-formly/issues/998