### PR TITLE
fix(core): avoid duplicate templateManipulator wrapper during rebuild

### DIFF
--- a/src/core/src/lib/services/formly.form.builder.spec.ts
+++ b/src/core/src/lib/services/formly.form.builder.spec.ts
@@ -91,6 +91,9 @@ describe('FormlyFormBuilder service', () => {
       };
       builder.buildForm(form, [field], {}, {});
 
+      // preWrapper and postWrapper should be applied only once when rebuild form
+      builder.buildForm(form, [field], {}, {});
+
       expect(field.wrappers).toEqual(['preWrapper', 'wrapper', 'postWrapper']);
     });
   });

--- a/src/core/src/lib/services/formly.form.builder.ts
+++ b/src/core/src/lib/services/formly.form.builder.ts
@@ -337,15 +337,19 @@ export class FormlyFormBuilder {
     }
 
     this.mergeTemplateManipulators(templateManipulators, this.formlyConfig.templateManipulators);
-
-    const preWrappers = templateManipulators.preWrapper.map(m => m(field)).filter(type => type),
-      postWrappers = templateManipulators.postWrapper.map(m => m(field)).filter(type => type);
-
     if (!field.wrappers) {
       field.wrappers = [];
     }
 
-    field.wrappers = [...preWrappers, ...(field.wrappers || []), ...postWrappers];
+    const preWrappers = templateManipulators.preWrapper
+      .map(m => m(field))
+      .filter(wrapper => wrapper && field.wrappers.indexOf(wrapper) === -1);
+
+    const postWrappers = templateManipulators.postWrapper
+      .map(m => m(field))
+      .filter(wrapper => wrapper && field.wrappers.indexOf(wrapper) === -1);
+
+    field.wrappers = [...preWrappers, ...field.wrappers, ...postWrappers];
   }
 
   private mergeTemplateManipulators(source: TemplateManipulators, target: TemplateManipulators) {


### PR DESCRIPTION
fix #997
