### PR TITLE
docs(demo): add example of ngx-datatable integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 npm-debug.log
 yarn-error.log
 coverage
+hooks

--- a/demo/src/app/examples/advanced/datatable-integration/app.component.html
+++ b/demo/src/app/examples/advanced/datatable-integration/app.component.html
@@ -1,0 +1,5 @@
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form">
+    <button type="submit" class="btn btn-primary submit-button" [disabled]="!form.valid">Submit</button>
+  </formly-form>
+</form>

--- a/demo/src/app/examples/advanced/datatable-integration/app.component.ts
+++ b/demo/src/app/examples/advanced/datatable-integration/app.component.ts
@@ -1,0 +1,110 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core/';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  form = new FormGroup({});
+  model: any;
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      className: 'section-label',
+      template: '<h5>Personal data</h5>',
+    },
+    {
+      fieldGroupClassName: 'row',
+      fieldGroup: [
+      {
+        key: 'name',
+        type: 'input',
+        className: 'col-md-6',
+        templateOptions: {
+          label: 'Name',
+          required: true,
+        },
+      },
+      {
+        key: 'surname',
+        type: 'input',
+        className: 'col-md-6',
+        templateOptions: {
+          label: 'Surname',
+          required: true,
+        },
+      },
+    ]},
+    {
+      key: 'investments',
+      type: 'datatable',
+      fieldArray: {
+        fieldGroup: [
+          {
+            type: 'input',
+            key: 'investmentName',
+            templateOptions: {
+              label: 'Name of Investment:',
+              required: true,
+            },
+          },
+          {
+            type: 'input',
+            key: 'investmentDate',
+            templateOptions: {
+              type: 'date',
+              label: 'Date of Investment:',
+            },
+          },
+          {
+            type: 'input',
+            key: 'stockIdentifier',
+            templateOptions: {
+              label: 'Stock Identifier:',
+              addonRight: {
+                class: 'fa fa-code',
+                onClick: (to, fieldType, $event) => console.log(to, fieldType, $event),
+              },
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  constructor() {
+    this.fetch((data) => this.model = data);
+  }
+
+
+  submit() {
+    alert(JSON.stringify(this.model));
+  }
+
+  fetch(cb) {
+    cb({
+      name: 'name1',
+      surname: 'surname1',
+      investments: [
+        {
+          investmentName: 'project1',
+          investmentDate: '',
+          stockIdentifier: 1,
+        },
+        {
+          investmentName: 'project2',
+          investmentDate: '',
+          stockIdentifier: 2,
+        },
+        {
+          investmentName: 'project3',
+          investmentDate: '',
+          stockIdentifier: 3,
+        },
+      ],
+    });
+  }
+}

--- a/demo/src/app/examples/advanced/datatable-integration/app.module.ts
+++ b/demo/src/app/examples/advanced/datatable-integration/app.module.ts
@@ -1,0 +1,42 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core/';
+import { FormlyBootstrapModule } from '@ngx-formly/bootstrap/';
+
+import { AppComponent } from './app.component';
+import { DatatableTypeComponent } from './datatable.type';
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormlyBootstrapModule,
+    NgxDatatableModule,
+    FormlyModule.forRoot({
+      types: [
+        {
+          name: 'datatable',
+          component: DatatableTypeComponent,
+          defaultOptions: {
+            templateOptions: {
+              columnMode: 'force',
+              rowHeight: 'auto',
+              headerHeight: '40',
+              footerHeight: '40',
+              limit: '10',
+              scrollbarH: 'true',
+              reorderable: 'reorderable',
+            },
+          },
+        },
+      ],
+    }),
+  ],
+  declarations: [
+    AppComponent,
+    DatatableTypeComponent,
+  ],
+})
+export class AppModule { }

--- a/demo/src/app/examples/advanced/datatable-integration/config.module.ts
+++ b/demo/src/app/examples/advanced/datatable-integration/config.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [{
+            title: 'Datatable',
+            description: `
+              This demonstrates using
+              <code>ngx-datatable</code> inside of a custom type in order to create an input datatable.
+            `,
+            component: AppComponent,
+            files: [
+              { file: 'app.component.html', content: require('!!prismjs-loader?lang=html!./app.component.html'), filecontent: require('!!raw-loader?lang=html!./app.component.html') },
+              { file: 'app.component.ts', content: require('!!prismjs-loader?lang=typescript!./app.component.ts'), filecontent: require('!!raw-loader?lang=typescript!./app.component.ts') },
+              { file: 'app.module.ts', content: require('!!prismjs-loader?lang=typescript!./app.module.ts'), filecontent: require('!!raw-loader?lang=typescript!./app.module.ts') },
+              { file: 'datatable.type.ts', content: require('!!prismjs-loader?lang=typescript!./datatable.type.ts'), filecontent: require('!!raw-loader?lang=typescript!./datatable.type.ts') },
+            ],
+          }],
+        },
+      },
+    ]),
+  ],
+  entryComponents: [AppComponent],
+})
+export class ConfigModule { }

--- a/demo/src/app/examples/advanced/datatable-integration/datatable.type.ts
+++ b/demo/src/app/examples/advanced/datatable-integration/datatable.type.ts
@@ -1,0 +1,60 @@
+import { Component, ViewChild, TemplateRef, OnInit } from '@angular/core';
+import { FormlyFieldConfig, FieldArrayType, FormlyFormBuilder } from '@ngx-formly/core';
+import { TableColumn } from '@swimlane/ngx-datatable/release/types';
+
+
+@Component({
+  selector: 'formly-field-datatable',
+  template: `
+    <ngx-datatable
+      #table
+      class="bootstrap"
+      [rows]="model"
+      [columns]="columns"
+      [columnMode]="to.columnMode"
+      [rowHeight]="to.rowHeight"
+      [headerHeight]="to.headerHeight"
+      [footerHeight]="to.footerHeight"
+      [limit]="to.limit"
+      [scrollbarH]="to.scrollbarH"
+      [reorderable]="to.reorderable"
+      [externalSorting]="true"
+      [selectionType]="'single'">
+      <ng-template #genericcolumn ngx-datatable-cell-template let-rowIndex="rowIndex" let-value="value" let-row="row" let-column="column">
+        <formly-field
+          [model]="getModel(model,column,rowIndex)"
+          [field]="getField(field,column, rowIndex)"
+          [options]="options"
+          [form]="formControl">
+        </formly-field>
+      </ng-template>
+    </ngx-datatable>
+`,
+})
+
+export class DatatableTypeComponent extends FieldArrayType implements OnInit {
+  @ViewChild('genericcolumn') public genericcolumn: TemplateRef<any>;
+
+  // column description
+  columns: TableColumn[];
+
+  ngOnInit() {
+    this.columns = this.field.fieldArray.fieldGroup.map(el => ({
+      name: el.templateOptions.label,
+      prop: el.key,
+      cellTemplate: this.genericcolumn,
+    }));
+  }
+
+  constructor(builder: FormlyFormBuilder) {
+    super(builder);
+  }
+
+  getField(field: FormlyFieldConfig, column: TableColumn, rowIndex: number ): FormlyFieldConfig {
+    return field.fieldGroup[rowIndex].fieldGroup.find(f => f.key === column.prop);
+  }
+
+  getModel(model, column: TableColumn, rowIndex): any {
+    return model[rowIndex];
+  }
+}

--- a/demo/src/app/examples/examples.component.ts
+++ b/demo/src/app/examples/examples.component.ts
@@ -60,6 +60,7 @@ export class ExamplesComponent {
       { href: './advanced/repeating-section', text: 'Repeating Section' },
       { href: './advanced/multi-step-form', text: 'Multi-Step Form' },
       { href: './advanced/tabs', text: 'Tabs Form' },
+      { href: './advanced/datatable-integration', text: 'ngx-datatable Integration' },
     ]},
     { title: 'Other', links: [
       { href: './other/cascaded-select', text: 'Cascaded Select' },

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -56,6 +56,7 @@ import { ExamplesComponent } from './examples.component';
         // Advanced
         { path: 'advanced', children: [
           { path: 'repeating-section', loadChildren: './advanced/repeating-section/config.module#ConfigModule' },
+          { path: 'datatable-integration', loadChildren: './advanced/datatable-integration/config.module#ConfigModule' },
           { path: 'multi-step-form', loadChildren: './advanced/multi-step-form/config.module#ConfigModule' },
           { path: 'tabs', loadChildren: './advanced/tabs/config.module#ConfigModule' },
         ]},

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@progress/kendo-angular-intl": "^1.4.0",
     "@progress/kendo-angular-l10n": "^1.1.0",
     "@progress/kendo-theme-default": "^2.50.0",
+    "@swimlane/ngx-datatable": "^13.0.1",
     "bootstrap": "^4.1.2",
     "core-js": "^2.5.7",
     "ionic-angular": "^3.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,6 +488,10 @@
     semver "^5.3.0"
     semver-intersect "^1.1.2"
 
+"@swimlane/ngx-datatable@^13.0.1":
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/@swimlane/ngx-datatable/-/ngx-datatable-13.0.1.tgz#6e949e19130b2054e2715d30d158751c4fbaa502"
+
 "@telerik/kendo-draggable@^1.5.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@telerik/kendo-draggable/-/kendo-draggable-1.7.1.tgz#b1fa1ebadd7ad5eb3d437d8353ee09caa04888e5"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
add docs with example of datatable integration 
ngx-datatable

issue: custom type with ngx-datatable #1061

**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
![ex](https://user-images.githubusercontent.com/11843561/43204433-16e6d01e-9021-11e8-848c-654c5677a3c1.PNG)



**Other information**:

@aitboudad  I added the example.