### PR TITLE
fix(kendo): use KENDO prefix in config name

### DIFF
--- a/src/kendo/src/lib/ui-kendo.config.ts
+++ b/src/kendo/src/lib/ui-kendo.config.ts
@@ -20,7 +20,7 @@ export const FIELD_TYPE_COMPONENTS = [
   FormlyWrapperFormField,
 ];
 
-export const PRIME_NG_FORMLY_CONFIG: ConfigOption = {
+export const KENDO_FORMLY_CONFIG: ConfigOption = {
   types: [
     {
       name: 'input',

--- a/src/kendo/src/lib/ui-kendo.module.ts
+++ b/src/kendo/src/lib/ui-kendo.module.ts
@@ -6,7 +6,7 @@ import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
 
 import { FormlyModule } from '@ngx-formly/core';
 import { FormlySelectModule } from '@ngx-formly/core/select';
-import { PRIME_NG_FORMLY_CONFIG, FIELD_TYPE_COMPONENTS } from './ui-kendo.config';
+import { KENDO_FORMLY_CONFIG, FIELD_TYPE_COMPONENTS } from './ui-kendo.config';
 
 @NgModule({
   declarations: FIELD_TYPE_COMPONENTS,
@@ -15,7 +15,7 @@ import { PRIME_NG_FORMLY_CONFIG, FIELD_TYPE_COMPONENTS } from './ui-kendo.config
     DropDownsModule,
     ReactiveFormsModule,
     FormlySelectModule,
-    FormlyModule.forRoot(PRIME_NG_FORMLY_CONFIG),
+    FormlyModule.forRoot(KENDO_FORMLY_CONFIG),
   ],
 })
 export class FormlyKendoModule {}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Small Bug Fix that corrects the name of the config object in the Kendo layout.

**What is the current behavior? (You can also link to an open issue here)**

Unchanged.

**What is the new behavior (if this is a feature change)?**

Unchanged.

**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
