### PR TITLE
fix(core): array-type.ts to have immutable model

### DIFF
--- a/src/core/src/lib/templates/field-array.type.ts
+++ b/src/core/src/lib/templates/field-array.type.ts
@@ -13,7 +13,7 @@ export abstract class FieldArrayType extends FieldType {
 
   add(i?: number, initialModel?: any) {
     i = isNullOrUndefined(i) ? this.field.fieldGroup.length : i;
-    this.model.splice(i, 0, initialModel ? clone(initialModel) : undefined);
+    this.model = [...this.model.splice(i, 0, initialModel ? clone(initialModel) : undefined)];
 
     (<any> this.options)._buildForm();
   }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug Fix in a new Feature.  The array-type.ts type in core should support immutable model changes

**What is the current behavior? (You can also link to an open issue here)**
currently, you cannot directly change the model for a FieldType due to the set function being deprecated.  the ArrayType that extends it appends an item using .splice instead of using the spread operator [...model]. Because of this, when a library, like material and its mat-table, expects immutable changes from a model they aren't supported out of the box.  The work around being to encapsulate in a custom array-type a separate field that properly returns an immutable model when reading said value


**What is the new behavior (if this is a feature change)?**
With the changes given, this updates the base library to supporting immutable model changes thereby supporting other libs that expect immutable models


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**
stackblitz of the issue and work around
https://stackblitz.com/edit/angular-rv7jtn

hit Add item to bring up a nested form.  hit save to save that item and what should happen is it adds another to the model and shows in the table.  the model is updated (as you can see in the number changes in the header) but the table is not due to the fact that basing the table off the model yields the same array reference.  To fix follow the comments and it will work properly however I think the preferred fix would be this PR.

This particular use case is being able to use formly arrays based on json schema generated formly configs but having a readonly list and an imbedded form for adding singles that can be extended to be a modal or a simple form as I have it implemented there.

Currently, there are no tests written that support the code.   Also, due to it being a small change I simply edited on GitHub.