### PR TITLE
fix(material): make sure input type number emits the correct value

### DIFF
--- a/src/material/input/src/input.type.ts
+++ b/src/material/input/src/input.type.ts
@@ -5,15 +5,29 @@ import { FieldType } from '@ngx-formly/material/form-field';
 @Component({
   selector: 'formly-field-mat-input',
   template: `
-    <input matInput
+    <input *ngIf="type !== 'number'; else numberTmp"
+      matInput
       [id]="id"
-      [type]="to.type || 'text'"
+      [type]="type || 'text'"
       [errorStateMatcher]="errorStateMatcher"
       [formControl]="formControl"
       [formlyAttributes]="field"
       [placeholder]="to.placeholder">
+    <ng-template #numberTmp>
+      <input matInput
+             [id]="id"
+             type="number"
+             [errorStateMatcher]="errorStateMatcher"
+             [formControl]="formControl"
+             [formlyAttributes]="field"
+             [placeholder]="to.placeholder">
+    </ng-template>
   `,
 })
 export class FormlyFieldInput extends FieldType implements OnInit {
   @ViewChild(MatInput) formFieldControl: MatInput;
+
+  get type() {
+    return this.to.type || 'text';
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix for the `<input type="number" >` in the Material templates.

**What is the current behavior? (You can also link to an open issue here)**

Currently the value emitted is a string:

```
{
  "Input": "42"
}
```


**What is the new behavior (if this is a feature change)?**

New behavior outputs a number:
```
{
  "Input": 42
}
```


**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:

Fixes issue mentioned in #729.

I've used the same implementation as in the [Bootstrap template](https://github.com/formly-js/ngx-formly/blob/master/src/bootstrap/src/lib/types/input.ts):