### PR TITLE
refactor(material): enable TypeScript strict mode

### DIFF
--- a/src/core/src/lib/templates/field.type.ts
+++ b/src/core/src/lib/templates/field.type.ts
@@ -15,14 +15,14 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
   set form(form) { console.warn(`NgxFormly: passing 'form' input to '${this.constructor.name}' component is not required anymore, you may remove it!`); }
 
   @Input()
-  get options(): F['options'] { return this.field.options; }
+  get options() { return this.field.options; }
   set options(options: F['options']) { console.warn(`NgxFormly: passing 'options' input to '${this.constructor.name}' component is not required anymore, you may remove it!`); }
 
   get key() { return this.field.key; }
 
-  get formControl(): F['formControl'] { return this.field.formControl; }
+  get formControl() { return this.field.formControl; }
 
-  get to(): F['templateOptions'] { return this.field.templateOptions; }
+  get to() { return this.field.templateOptions || {}; }
 
   get showError(): boolean { return this.options.showError(this); }
 

--- a/src/material/checkbox/src/checkbox.type.ts
+++ b/src/material/checkbox/src/checkbox.type.ts
@@ -11,7 +11,7 @@ import { FocusMonitor } from '@angular/cdk/a11y';
       [id]="id"
       [formlyAttributes]="field"
       (change)="change($event)"
-      [indeterminate]="to.indeterminate && field.formControl.value === null"
+      [indeterminate]="to.indeterminate && formControl.value === null"
       [color]="to.color"
       [labelPosition]="to.align || to.labelPosition">
       {{ to.label }}
@@ -20,7 +20,7 @@ import { FocusMonitor } from '@angular/cdk/a11y';
   `,
 })
 export class FormlyFieldCheckbox extends FieldType implements AfterViewInit, OnDestroy {
-  @ViewChild(MatCheckbox) checkbox: MatCheckbox;
+  @ViewChild(MatCheckbox) checkbox!: MatCheckbox;
 
   constructor(private focusMonitor: FocusMonitor) {
     super();

--- a/src/material/datepicker/src/datepicker.type.ts
+++ b/src/material/datepicker/src/datepicker.type.ts
@@ -27,5 +27,5 @@ import { MatInput } from '@angular/material/input';
   `,
 })
 export class FormlyDatepickerTypeComponent extends FieldType {
-  @ViewChild(MatInput) formFieldControl: MatInput;
+  @ViewChild(MatInput) formFieldControl!: MatInput;
 }

--- a/src/material/form-field/src/field.type.ts
+++ b/src/material/form-field/src/field.type.ts
@@ -4,9 +4,14 @@ import { Subject } from 'rxjs';
 import { MatFormField, MatFormFieldControl } from '@angular/material/form-field';
 import { FormlyErrorStateMatcher } from './formly.error-state-matcher';
 
-export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig> extends CoreFieldType<F> implements OnInit, AfterViewInit, OnDestroy, MatFormFieldControl<any> {
-  @ViewChild('matPrefix') matPrefix: TemplateRef<any>;
-  @ViewChild('matSuffix') matSuffix: TemplateRef<any>;
+export interface MatFormlyFieldConfig extends FormlyFieldConfig {
+  _matPrefix: TemplateRef<any>;
+  _matSuffix: TemplateRef<any>;
+}
+
+export abstract class FieldType<F extends MatFormlyFieldConfig = MatFormlyFieldConfig> extends CoreFieldType<F> implements OnInit, AfterViewInit, OnDestroy, MatFormFieldControl<any> {
+  @ViewChild('matPrefix') matPrefix!: TemplateRef<any>;
+  @ViewChild('matSuffix') matSuffix!: TemplateRef<any>;
 
   formFieldControl: MatFormFieldControl<any> = this;
   errorStateMatcher = new FormlyErrorStateMatcher(this);
@@ -30,7 +35,6 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
   }
 
   ngOnDestroy() {
-    this.formFieldControl = null;
     if (this.formField) {
       delete this.formField._control;
     }
@@ -44,7 +48,7 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
   }
 
   get errorState() {
-    const showError = this.options.showError(this);
+    const showError = this.options!.showError!(this);
     if (showError !== this._errorState) {
       this._errorState = showError;
       this.stateChanges.next();
@@ -59,15 +63,15 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
     }
 
     if ((<any> this.field.type) instanceof Type) {
-      return this.field.type.constructor.name;
+      return this.field.type!.constructor.name;
     }
 
-    return this.field.type;
+    return this.field.type!;
   }
-  get focused() { return this.field.focus && !this.disabled; }
-  get disabled() { return this.to.disabled; }
-  get required() { return this.to.required; }
-  get placeholder() { return this.to.placeholder; }
+  get focused() { return !!this.field.focus && !this.disabled; }
+  get disabled() { return !!this.to.disabled; }
+  get required() { return !!this.to.required; }
+  get placeholder() { return this.to.placeholder || ''; }
   get shouldPlaceholderFloat() { return this.shouldLabelFloat; }
   get value() { return this.formControl.value; }
   get ngControl() { return this.formControl as any; }

--- a/src/material/form-field/src/form-field.wrapper.ts
+++ b/src/material/form-field/src/form-field.wrapper.ts
@@ -4,6 +4,8 @@ import { MatFormField } from '@angular/material/form-field';
 import { MatFormFieldControl } from '@angular/material/form-field';
 import { Subject } from 'rxjs';
 
+import { MatFormlyFieldConfig } from './field.type';
+
 @Component({
   selector: 'formly-wrapper-mat-form-field',
   template: `
@@ -21,11 +23,11 @@ import { Subject } from 'rxjs';
       </mat-label>
 
       <ng-container matPrefix>
-        <ng-container *ngTemplateOutlet="to.prefix ? to.prefix : field['_matPrefix']"></ng-container>
+        <ng-container *ngTemplateOutlet="to.prefix ? to.prefix : field._matPrefix"></ng-container>
       </ng-container>
 
       <ng-container matSuffix>
-        <ng-container *ngTemplateOutlet="to.suffix ? to.suffix : field['_matSuffix']"></ng-container>
+        <ng-container *ngTemplateOutlet="to.suffix ? to.suffix : field._matSuffix"></ng-container>
       </ng-container>
 
       <!-- fix https://github.com/angular/material2/issues/7737 by setting id to null  -->
@@ -38,9 +40,9 @@ import { Subject } from 'rxjs';
   `,
   providers: [{ provide: MatFormFieldControl, useExisting: FormlyWrapperFormField }],
 })
-export class FormlyWrapperFormField extends FieldWrapper implements OnInit, OnDestroy, MatFormFieldControl<any>, AfterViewInit, AfterContentChecked {
-  @ViewChild('fieldComponent', { read: ViewContainerRef }) fieldComponent: ViewContainerRef;
-  @ViewChild(MatFormField) formField: MatFormField;
+export class FormlyWrapperFormField extends FieldWrapper<MatFormlyFieldConfig> implements OnInit, OnDestroy, MatFormFieldControl<any>, AfterViewInit, AfterContentChecked {
+  @ViewChild('fieldComponent', { read: ViewContainerRef }) fieldComponent!: ViewContainerRef;
+  @ViewChild(MatFormField) formField!: MatFormField;
 
   stateChanges = new Subject<void>();
   _errorState = false;
@@ -59,7 +61,7 @@ export class FormlyWrapperFormField extends FieldWrapper implements OnInit, OnDe
     });
 
     // fix for https://github.com/angular/material2/issues/11437
-    if (this.field.hide && this.field.templateOptions.appearance === 'outline') {
+    if (this.field.hide && this.field.templateOptions!.appearance === 'outline') {
       this.initialGapCalculated = true;
     }
   }
@@ -93,7 +95,7 @@ export class FormlyWrapperFormField extends FieldWrapper implements OnInit, OnDe
   }
 
   get errorState() {
-    const showError = this.options.showError(this);
+    const showError = this.options!.showError!(this);
     if (showError !== this._errorState) {
       this._errorState = showError;
       this.stateChanges.next();
@@ -102,10 +104,10 @@ export class FormlyWrapperFormField extends FieldWrapper implements OnInit, OnDe
     return showError;
   }
   get controlType() { return this.to.type; }
-  get focused() { return this.field.focus && !this.disabled; }
-  get disabled() { return this.to.disabled; }
-  get required() { return this.to.required; }
-  get placeholder() { return this.to.placeholder; }
+  get focused() { return !!this.field.focus && !this.disabled; }
+  get disabled() { return !!this.to.disabled; }
+  get required() { return !!this.to.required; }
+  get placeholder() { return this.to.placeholder || ''; }
   get shouldPlaceholderFloat() { return this.shouldLabelFloat; }
   get value() { return this.formControl.value; }
   get ngControl() { return this.formControl as any; }

--- a/src/material/input/src/input.type.ts
+++ b/src/material/input/src/input.type.ts
@@ -26,7 +26,7 @@ import { FieldType } from '@ngx-formly/material/form-field';
   `,
 })
 export class FormlyFieldInput extends FieldType implements OnInit {
-  @ViewChild(MatInput) formFieldControl: MatInput;
+  @ViewChild(MatInput) formFieldControl!: MatInput;
 
   get type() {
     return this.to.type || 'text';

--- a/src/material/multicheckbox/src/multicheckbox.type.ts
+++ b/src/material/multicheckbox/src/multicheckbox.type.ts
@@ -18,7 +18,7 @@ import { FieldType } from '@ngx-formly/material/form-field';
   `,
 })
 export class FormlyFieldMultiCheckbox extends FieldType {
-  onChange(value, checked) {
+  onChange(value: any, checked: boolean) {
     if (this.to.type === 'array') {
       this.formControl.patchValue(checked
         ? [...(this.formControl.value || []), value]

--- a/src/material/native-select/src/native-select.type.ts
+++ b/src/material/native-select/src/native-select.type.ts
@@ -19,5 +19,5 @@ import { MatInput } from '@angular/material/input';
   `,
 })
 export class FormlyFieldNativeSelect extends FieldType {
-  @ViewChild(MatInput) formFieldControl: MatInput;
+  @ViewChild(MatInput) formFieldControl!: MatInput;
 }

--- a/src/material/radio/src/radio.type.ts
+++ b/src/material/radio/src/radio.type.ts
@@ -17,7 +17,7 @@ import { MatRadioGroup, MatRadioChange } from '@angular/material/radio';
   `,
 })
 export class FormlyFieldRadio extends FieldType {
-  @ViewChild(MatRadioGroup) radioGroup: MatRadioGroup;
+  @ViewChild(MatRadioGroup) radioGroup!: MatRadioGroup;
 
   onContainerClick(event: MouseEvent): void {
     if (this.radioGroup._radios.length) {

--- a/src/material/select/src/select.type.ts
+++ b/src/material/select/src/select.type.ts
@@ -27,7 +27,7 @@ import { FieldType } from '@ngx-formly/material/form-field';
   `,
 })
 export class FormlyFieldSelect extends FieldType {
-  @ViewChild(MatSelect) formFieldControl: MatSelect;
+  @ViewChild(MatSelect) formFieldControl!: MatSelect;
 
   change($event: MatSelectChange) {
     if (this.to.change) {

--- a/src/material/slider/src/slider.type.ts
+++ b/src/material/slider/src/slider.type.ts
@@ -15,7 +15,7 @@ import { MatSlider } from '@angular/material/slider';
   `,
 })
 export class FormlySliderTypeComponent extends FieldType {
-  @ViewChild(MatSlider) slider: MatSlider;
+  @ViewChild(MatSlider) slider!: MatSlider;
 
   onContainerClick(event: MouseEvent): void {
     this.slider.focus();

--- a/src/material/textarea/src/textarea.type.ts
+++ b/src/material/textarea/src/textarea.type.ts
@@ -18,5 +18,5 @@ import { FieldType } from '@ngx-formly/material/form-field';
   `,
 })
 export class FormlyFieldTextArea extends FieldType implements OnInit {
-  @ViewChild(MatInput) formFieldControl: MatInput;
+  @ViewChild(MatInput) formFieldControl!: MatInput;
 }

--- a/src/material/toggle/src/toggle.type.ts
+++ b/src/material/toggle/src/toggle.type.ts
@@ -14,7 +14,7 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
   `,
 })
 export class FormlyToggleTypeComponent extends FieldType {
-  @ViewChild(MatSlideToggle) slideToggle: MatSlideToggle;
+  @ViewChild(MatSlideToggle) slideToggle!: MatSlideToggle;
 
   onContainerClick(event: MouseEvent): void {
     this.slideToggle.focus();

--- a/src/material/tsconfig.lib.json
+++ b/src/material/tsconfig.lib.json
@@ -12,6 +12,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "types": [],
+    "strict": true,
     "lib": [
       "dom",
       "es2015"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
enhancement


**What is the current behavior? (You can also link to an open issue here)**
https://github.com/formly-js/ngx-formly/issues/1276#issuecomment-443167320


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:
No functionality was changed that would require a unit test. Mostly adjusting TypeScript to a strict ruleset. 