### PR TITLE
refactor(bootstrap): enable TypeScript strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12932,9 +12932,9 @@
       }
     },
     "primeng": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-6.1.7.tgz",
-      "integrity": "sha512-yns96Qlq8TVpVf9Gi08Z+faYX2OF9GNOvQGMz5v0R/lV8B1IPxddQPKqN/C09iB99W5xszJbDiS0yBOxuVFUhg=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-7.0.0.tgz",
+      "integrity": "sha512-PrEEnp0VPbzsUQdpB/4KtUdRxaWwpprHy+IpUi09C42OAI2zqdTVIC0AaW81gDAGQyW7XraCP9EFI8KT4nC9GA=="
     },
     "prism-hightlight-loader": {
       "version": "0.1.1",

--- a/src/bootstrap/src/lib/run/addon.ts
+++ b/src/bootstrap/src/lib/run/addon.ts
@@ -1,11 +1,13 @@
-import { FormlyConfig } from '@ngx-formly/core';
+import { FormlyConfig, FormlyFieldConfig } from '@ngx-formly/core';
 
 export class TemplateAddons {
   run(fc: FormlyConfig) {
-    fc.templateManipulators.postWrapper.push((field) => {
+    fc.templateManipulators.postWrapper.push((field: FormlyFieldConfig) => {
       if (field && field.templateOptions && (field.templateOptions.addonLeft || field.templateOptions.addonRight)) {
         return 'addons';
       }
+
+      return '';
     });
   }
 }

--- a/src/bootstrap/src/lib/types/checkbox.ts
+++ b/src/bootstrap/src/lib/types/checkbox.ts
@@ -7,7 +7,7 @@ import { FieldType } from '@ngx-formly/core';
     <div class="custom-control custom-checkbox">
       <input class="custom-control-input" type="checkbox"
         [class.is-invalid]="showError"
-        [indeterminate]="to.indeterminate && field.formControl.value === null"
+        [indeterminate]="to.indeterminate && formControl.value === null"
         [formControl]="formControl"
         [formlyAttributes]="field">
       <label class="custom-control-label" [for]="id">

--- a/src/bootstrap/src/lib/types/multicheckbox.ts
+++ b/src/bootstrap/src/lib/types/multicheckbox.ts
@@ -18,7 +18,7 @@ import { FieldType } from '@ngx-formly/core';
   `,
 })
 export class FormlyFieldMultiCheckbox extends FieldType {
-  onChange(value, checked) {
+  onChange(value: any, checked: boolean) {
     if (this.to.type === 'array') {
       this.formControl.patchValue(checked
         ? [...(this.formControl.value || []), value]

--- a/src/bootstrap/src/lib/wrappers/addons.ts
+++ b/src/bootstrap/src/lib/wrappers/addons.ts
@@ -34,7 +34,7 @@ import { FieldWrapper } from '@ngx-formly/core';
   `],
 })
 export class FormlyWrapperAddons extends FieldWrapper {
-  @ViewChild('fieldComponent', {read: ViewContainerRef}) fieldComponent: ViewContainerRef;
+  @ViewChild('fieldComponent', {read: ViewContainerRef}) fieldComponent!: ViewContainerRef;
 
   addonRightClick($event: any) {
     if (this.to.addonRight.onClick) {

--- a/src/bootstrap/src/lib/wrappers/form-field.wrapper.ts
+++ b/src/bootstrap/src/lib/wrappers/form-field.wrapper.ts
@@ -21,5 +21,5 @@ import { FieldWrapper } from '@ngx-formly/core';
   `,
 })
 export class FormlyWrapperFormField extends FieldWrapper {
-  @ViewChild('fieldComponent', { read: ViewContainerRef }) fieldComponent: ViewContainerRef;
+  @ViewChild('fieldComponent', { read: ViewContainerRef }) fieldComponent!: ViewContainerRef;
 }

--- a/src/bootstrap/tsconfig.lib.json
+++ b/src/bootstrap/tsconfig.lib.json
@@ -12,6 +12,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "types": [],
+    "strict": true,
     "lib": [
       "dom",
       "es2015"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
enhancement


**What is the current behavior? (You can also link to an open issue here)**
TypeScript is not in strict mode. Discussed to enable it for `ngx-formly` in the issue: #1276


**What is the new behavior (if this is a feature change)?**
Enabling strict typescript mode for bootstrap.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:
No functionality was changed that would require a unit test. Mostly adjusting TypeScript to a strict ruleset.