### PR TITLE
test(core):  Tests for json-schema converter feature

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -120,7 +120,7 @@
     },
     "@ngx-formly/core": {
       "root": "src/core",
-      "sourceRoot": "src/core/src",
+      "sourceRoot": "src/core",
       "projectType": "library",
       "prefix": "lib",
       "architect": {

--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -1,9 +1,283 @@
-// import { FormlyJsonschema } from './formly-json-schema.service';
 
-// describe('Service: FormlyJsonschema', () => {
-//   let formlyJsonschema: FormlyJsonschema;
+import { FormlyJsonschema } from './formly-json-schema.service';
+import { JSONSchema7 } from 'json-schema';
+import { FormlyFieldConfig, FormlyTemplateOptions } from '@ngx-formly/core';
 
-//   beforeEach(() => {
-//     formlyJsonschema = new FormlyJsonschema();
-//   });
-// });
+describe('Service: FormlyJsonschema', () => {
+  let formlyJsonschema: FormlyJsonschema;
+  const emmptyTemplateOptions: FormlyTemplateOptions = {
+    min: undefined,
+    max: undefined,
+    minLength: undefined,
+    maxLength: undefined,
+    label: undefined,
+    readonly: undefined,
+    pattern: undefined,
+    description: undefined,
+  };
+  beforeEach(() => {
+    formlyJsonschema = new FormlyJsonschema();
+  });
+
+  describe('keyword support', () => {
+    // TODO: Add support for exclusiveMinimum, exclusiveMaximum and multipleOf
+    // https://json-schema.org/latest/json-schema-validation.html#numeric
+    describe('number validation keywords', () => {
+      it('should support minimum and maximum', () => {
+        const numSchema: JSONSchema7 = {
+          type: 'number',
+          minimum: 5,
+          maximum: 10,
+        };
+        const formlyConfig = formlyJsonschema.toFieldConfig(numSchema);
+        expect(formlyConfig.templateOptions.min).toBe(numSchema.minimum);
+        expect(formlyConfig.templateOptions.max).toBe(numSchema.maximum);
+      });
+    });
+
+    // https://json-schema.org/latest/json-schema-validation.html#string
+    describe('string validation keywords', () => {
+      it('should support pattern', () => {
+        const stringSchema: JSONSchema7 = {
+          type: 'string',
+          pattern: 'Hello World!',
+        };
+        const formlyConfig = formlyJsonschema.toFieldConfig(stringSchema);
+        expect(formlyConfig.templateOptions.pattern).toBe(stringSchema.pattern);
+      });
+
+      it('should support minLength and maxLength', () => {
+        const stringSchema: JSONSchema7 = {
+          type: 'string',
+          minLength: 5,
+          maxLength: 10,
+        };
+        const formlyConfig = formlyJsonschema.toFieldConfig(stringSchema);
+        expect(formlyConfig.templateOptions.minLength).toBe(stringSchema.minLength);
+        expect(formlyConfig.templateOptions.maxLength).toBe(stringSchema.maxLength);
+      });
+    });
+
+    // TODO: Add support for minItems, maxItems, uniqueItems, contains
+    // https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4
+    describe('array validation keywords', () => {
+      it('supports array items keyword as object', () => {
+         const schema: JSONSchema7 = {
+           type: 'array',
+           items: { type: 'string' },
+         };
+
+         const config = formlyJsonschema.toFieldConfig(schema);
+
+         const childConfig: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'string', defaultValue: undefined };
+         const baseConfig: FormlyFieldConfig = {
+            type: 'array',
+            defaultValue: undefined,
+            templateOptions: { ...emmptyTemplateOptions },
+            fieldArray: childConfig,
+         };
+
+         expect(config).toEqual(baseConfig);
+      });
+
+      it('supports array items as array of schemas', () => {
+        const schema: JSONSchema7 = {
+          type: 'array',
+          items: [
+            { type: 'string' },
+            { type: 'number'},
+          ],
+        };
+
+        const config = formlyJsonschema.toFieldConfig(schema);
+
+        const childConfig: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'string', defaultValue: undefined };
+        const childConfig2: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'number', defaultValue: undefined };
+
+        expect(config.fieldArray).toEqual(childConfig);
+        // TODO: is this the best way to test this?
+        // artificially increase the length of the fieldGroup
+        // since the getter that is defined is based on that.
+        config.fieldGroup.push(null);
+        expect(config.fieldArray).toEqual(childConfig2);
+        expect(config.type).toEqual('array');
+      });
+
+      it('supports array additionalitems wheh array items are defined as an array of schemas', () => {
+        const schema: JSONSchema7 = {
+          type: 'array',
+          items: [
+            { type: 'string' },
+            { type: 'number'},
+          ],
+          additionalItems: { type: 'boolean' },
+        };
+
+        const config = formlyJsonschema.toFieldConfig(schema);
+
+        const childConfig: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'string', defaultValue: undefined };
+        const childConfig2: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'number', defaultValue: undefined };
+        const childConfig3: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'boolean', defaultValue: undefined };
+
+        expect(config.fieldArray).toEqual(childConfig);
+        // TODO: is this the best way to test this?
+        // artificially increase the length of the fieldGroup
+        // since the getter that is defined is based on that.
+        config.fieldGroup.push(null);
+        expect(config.fieldArray).toEqual(childConfig2);
+        config.fieldGroup.push(null);
+        // should return the additional items schema when the fieldGroup's length
+        // is greater than the number of items array config validatoins
+        expect(config.fieldArray).toEqual(childConfig3);
+        expect(config.type).toEqual('array');
+      });
+    });
+
+    // TODO: complete support for Object validation keywords
+    // https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5
+    describe('object validation keywords', () => {
+      it('supports properties and required keywords as well as nested objects', () => {
+        const schema: JSONSchema7 = {
+          type: 'object',
+          required: ['requiredField'],
+          properties: {
+            requiredField: { type: 'string' },
+            notRequired: { type: 'number' },
+            nested: {
+              type: 'object',
+              properties: {
+                nestedProp: { type: 'string' },
+              },
+            },
+          },
+        };
+
+        const config = formlyJsonschema.toFieldConfig(schema);
+
+        const child1: FormlyFieldConfig = {
+          type: 'string',
+          key: 'requiredField',
+          templateOptions: { ...emmptyTemplateOptions, required: true },
+          defaultValue: undefined,
+        };
+
+        const child2: FormlyFieldConfig = {
+          type: 'number',
+          key: 'notRequired',
+          templateOptions: { ...emmptyTemplateOptions },
+          defaultValue: undefined,
+        };
+
+        const nestedProp: FormlyFieldConfig = {
+          type: 'string',
+          key: 'nested.nestedProp',
+          templateOptions: { ...emmptyTemplateOptions },
+          defaultValue: undefined,
+        };
+
+        const nested: FormlyFieldConfig = {
+          type: 'object',
+          key: 'nested',
+          templateOptions: {...emmptyTemplateOptions },
+          defaultValue: undefined,
+          fieldGroup: [nestedProp],
+        };
+
+        expect(config.fieldGroup[0]).toEqual(child1);
+        expect(config.fieldGroup[1]).toEqual(child2);
+        expect(config.fieldGroup[2]).toEqual(nested);
+      });
+    });
+
+    // https://json-schema.org/latest/json-schema-validation.html#general
+    describe('any instance type validation keywords', () => {
+      it('should support type', () => {
+        const schema: JSONSchema7 = {
+          type: 'string',
+        };
+
+        const config = formlyJsonschema.toFieldConfig(schema);
+        expect(config.type).toBe(schema.type);
+      });
+
+      it('should support enum as strig array values', () => {
+        const schemaStringEnum: JSONSchema7 = {
+          type: 'string',
+          enum: ['The', 'Best', 'Forms',
+          ],
+        };
+
+        const schemaNumberEnum: JSONSchema7 = {
+          type: 'number',
+          enum: [1, 1.233333, 42, 1234163],
+        };
+
+        const schemaIntegerEnum: JSONSchema7 = {
+          type: 'integer',
+          enum: [1, 2, 3, 4, 5],
+        };
+
+        // labelProp and valueProp should be a function that returns what it is given
+        const config = formlyJsonschema.toFieldConfig(schemaStringEnum);
+        expect(config.type).toBe('enum');
+        expect(config.templateOptions.options).toEqual(schemaStringEnum.enum);
+        expect(config.templateOptions.labelProp('test')).toBe('test');
+        expect(config.templateOptions.valueProp('test')).toBe('test');
+
+        const config2 = formlyJsonschema.toFieldConfig(schemaNumberEnum);
+        expect(config2.parsers).toEqual([Number]);
+        expect(config2.type).toBe('enum');
+        expect(config2.templateOptions.options).toEqual(schemaNumberEnum.enum);
+        expect(config2.templateOptions.labelProp('test')).toBe('test');
+        expect(config2.templateOptions.valueProp('test')).toBe('test');
+
+        const config3 = formlyJsonschema.toFieldConfig(schemaIntegerEnum);
+        expect(config3.parsers).toEqual([Number]);
+        expect(config3.type).toBe('enum');
+        expect(config3.templateOptions.options).toEqual(schemaIntegerEnum.enum);
+        expect(config3.templateOptions.labelProp('test')).toBe('test');
+        expect(config3.templateOptions.valueProp('test')).toBe('test');
+      });
+
+      // TODO: add support for adding custom labels to enum values using oneOf/const
+      // https://github.com/json-schema-org/json-schema-spec/issues/57#issuecomment-247861695
+      // it('should support enum as oneOf structure', () => {
+      //   const schema: JSONSchema7 = {
+      //     type: 'number',
+      //   };
+
+      //   const config = formlyJsonschema.toFieldConfig(schema);
+      // });
+
+      // TODO: discuss const support possibly as hidden, already set field
+      // it('should support cosnt', () => {
+      //   const schema: JSONSchema7 = {
+      //     type: 'string',
+      //     const: 'string Const',
+      //   };
+
+      //   const config = formlyJsonschema.toFieldConfig(schema);
+      // });
+    });
+
+    // TODO: discuss support of writeOnly. Note: this may not be needed.
+    // TODO: discuss support of examples. By spec, default can be used in its place.
+    // https://json-schema.org/latest/json-schema-validation.html#rfc.section.10
+    describe('schema annotations', () => {
+      it('should support schema annotations', () => {
+        const schema: JSONSchema7 = {
+          title: 'Test title',
+          description: 'Test description',
+          readOnly: true,
+          default: 'Super Heroic Forms Generator',
+          type: 'string',
+        };
+        const config = formlyJsonschema.toFieldConfig(schema);
+        expect(config.templateOptions.label).toBe(schema.title);
+        expect(config.defaultValue).toBe(schema.default);
+        expect(config.templateOptions.description).toBe(schema.description);
+        expect(config.templateOptions.readonly).toBe(schema.readOnly);
+      });
+    });
+  });
+});

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -14,6 +14,8 @@ export class FormlyJsonschema {
       type: jsonSchema.type as JSONSchema7TypeName,
       defaultValue: jsonSchema.default,
       templateOptions: {
+        min: jsonSchema.minimum,
+        max: jsonSchema.maximum,
         minLength: jsonSchema.minLength,
         maxLength: jsonSchema.maxLength,
         label: jsonSchema.title,
@@ -37,7 +39,7 @@ export class FormlyJsonschema {
       case 'object': {
         field.fieldGroup = [];
         Object.keys(jsonSchema.properties).forEach(p => {
-          const child = this._toFieldConfig(<JSONSchema7> jsonSchema.properties[p], p);
+          const child = this._toFieldConfig(<JSONSchema7> jsonSchema.properties[p], key ? key + '.' + p : p);
           if (Array.isArray(jsonSchema.required) && jsonSchema.required.indexOf(p) !== -1) {
             child.templateOptions.required = true;
           }

--- a/src/core/src/lib/components/formly.field.config.ts
+++ b/src/core/src/lib/components/formly.field.config.ts
@@ -209,6 +209,7 @@ export interface FormlyTemplateOptions {
   pattern?: string|RegExp;
   required?: boolean;
   tabindex?: number;
+  readonly?: boolean;
   attributes?: { [key: string]: string|number };
   step?: number;
   focus?: FormlyAttributeEvent;


### PR DESCRIPTION
Added Tests for full coverage of current covered features
Added support for minimum/maximum
Added todo for things needed to be supported in the future
Added logic to support key hierarchy so configs can be rearranged
Added json-schema to code coverage through angular.json config

closes formly-js/ngx-formly/#1056

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
test additions for #1056 


**What is the current behavior? (You can also link to an open issue here)**
No tests exist and min/max are not supported


**What is the new behavior (if this is a feature change)?**
New tests exist and min/max are now supported.  Also added parent.child key relationships when creating the configs.


**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
